### PR TITLE
basepathがコードに入るように

### DIFF
--- a/docs/swagger/openapi.yml
+++ b/docs/swagger/openapi.yml
@@ -1,9 +1,6 @@
 openapi: 3.0.2
 servers:
-  - url: https://collection.trap.jp
-    variables:
-      basePath: 
-        default: /api
+  - url: https://collection.trap.jp/api
 info:
   description: "traPCollectionのAPI"
   version: "1.0.0"

--- a/generate/router.mustache
+++ b/generate/router.mustache
@@ -7,6 +7,6 @@ import (
 
 func SetupRouting(e *echo.Echo, api *Api) {
   {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
-  e.{{httpMethod}}("{{{basePathWithoutHost}}}{{{path}}}", {{baseName}}Handler(api.{{classname}}){{#authMethods}}, api.{{name}}Middleware{{/authMethods}}){{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
+  e.{{httpMethod}}("{{basePathWithoutHost}}{{path}}", {{baseName}}Handler(api.{{classname}}){{#authMethods}}, api.{{name}}Middleware{{/authMethods}}){{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 }
 


### PR DESCRIPTION
`/api`がエンドポイントに入るように直した。
結局、原因はopenapi.yamlのbasepathの定義の仕方だった。
ついでに、一箇所だけ無意味に3重中括弧なのも気持ち悪いので直した。
Close #39 