### PR TITLE
build時に不要な部分を除外

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -34,6 +34,6 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY --from=generate /local/ ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
-  go build -o main -ldflags "-s -w"
+  go build -o main -ldflags "-s -w" -tags main
 
 ENTRYPOINT dockerize -wait tcp://mariadb:3306 realize start --name='server' --install --run

--- a/docker/mock/server.Dockerfile
+++ b/docker/mock/server.Dockerfile
@@ -22,7 +22,7 @@ RUN go mod download
 
 COPY --from=generate /local/ ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
-  go build -o main -ldflags "-s -w"
+  go build -o main -ldflags "-s -w" -tags main
 RUN upx ./main
 
 

--- a/docker/mock/server.Dockerfile
+++ b/docker/mock/server.Dockerfile
@@ -17,7 +17,7 @@ FROM golang:1.14.2-alpine AS build
 RUN --mount=type=cache,target=/var/cache/apk apk add --update git upx
 
 WORKDIR /go/src/github.com/traPtitech/trap-collection-server
-COPY go.* ./
+COPY go.mod go.sum ./
 RUN go mod download
 
 COPY --from=generate /local/ ./

--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -22,7 +22,7 @@ RUN go mod download
 
 COPY --from=generate /local ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
-  go build -o main -ldflags "-s -w"
+  go build -o main -ldflags "-s -w" -tags main
 RUN upx ./main
 
 

--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -17,7 +17,7 @@ FROM golang:1.14.2-alpine AS build
 RUN --mount=type=cache,target=/var/cache/apk apk add --update git upx
 
 WORKDIR /go/src/github.com/traPtitech/trap-collection-server
-COPY go.* ./
+COPY go.mod go.sum ./
 RUN go mod download
 
 COPY --from=generate /local ./

--- a/model/db.go
+++ b/model/db.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	_ "github.com/go-sql-driver/mysql"
-	gomock "github.com/golang/mock/gomock"
 	"github.com/jinzhu/gorm"
 )
 
@@ -48,38 +47,6 @@ type DBMeta interface {
 
 // DB DB関連の構造体
 type DB struct {}
-
-// DBMock DB関連の構造体のMock
-type DBMock struct {
-	*MockGameIntroductionMeta
-	*MockGameVersionRelationMeta
-	*MockGameVersionMeta
-	*MockGameMeta
-	*MockLauncherVersionMeta
-	*MockMaintainerMeta
-	*MockPlayerMeta
-	*MockProductKeyMeta
-	*MockQuestionMeta
-	*MockResponseMeta
-}
-
-// NewDBMock DBのMockのコンストラクタ
-func NewDBMock(ctrl *gomock.Controller) DBMeta {
-	dbMock := new(DBMock)
-
-	dbMock.MockGameIntroductionMeta = NewMockGameIntroductionMeta(ctrl)
-	dbMock.MockGameVersionRelationMeta = NewMockGameVersionRelationMeta(ctrl)
-	dbMock.MockGameVersionMeta = NewMockGameVersionMeta(ctrl)
-	dbMock.MockGameMeta = NewMockGameMeta(ctrl)
-	dbMock.MockLauncherVersionMeta = NewMockLauncherVersionMeta(ctrl)
-	dbMock.MockMaintainerMeta = NewMockMaintainerMeta(ctrl)
-	dbMock.MockPlayerMeta = NewMockPlayerMeta(ctrl)
-	dbMock.MockProductKeyMeta = NewMockProductKeyMeta(ctrl)
-	dbMock.MockQuestionMeta = NewMockQuestionMeta(ctrl)
-	dbMock.MockResponseMeta = NewMockResponseMeta(ctrl)
-
-	return dbMock
-}
 
 //EstablishDB データベースに接続
 func EstablishDB() (*gorm.DB, error) {

--- a/model/db_mock.go
+++ b/model/db_mock.go
@@ -1,0 +1,38 @@
+// +build !main
+
+package model
+
+import gomock "github.com/golang/mock/gomock"
+
+
+// DBMock DB関連の構造体のMock
+type DBMock struct {
+	*MockGameIntroductionMeta
+	*MockGameVersionRelationMeta
+	*MockGameVersionMeta
+	*MockGameMeta
+	*MockLauncherVersionMeta
+	*MockMaintainerMeta
+	*MockPlayerMeta
+	*MockProductKeyMeta
+	*MockQuestionMeta
+	*MockResponseMeta
+}
+
+// NewDBMock DBのMockのコンストラクタ
+func NewDBMock(ctrl *gomock.Controller) *DBMock {
+	dbMock := new(DBMock)
+
+	dbMock.MockGameIntroductionMeta = NewMockGameIntroductionMeta(ctrl)
+	dbMock.MockGameVersionRelationMeta = NewMockGameVersionRelationMeta(ctrl)
+	dbMock.MockGameVersionMeta = NewMockGameVersionMeta(ctrl)
+	dbMock.MockGameMeta = NewMockGameMeta(ctrl)
+	dbMock.MockLauncherVersionMeta = NewMockLauncherVersionMeta(ctrl)
+	dbMock.MockMaintainerMeta = NewMockMaintainerMeta(ctrl)
+	dbMock.MockPlayerMeta = NewMockPlayerMeta(ctrl)
+	dbMock.MockProductKeyMeta = NewMockProductKeyMeta(ctrl)
+	dbMock.MockQuestionMeta = NewMockQuestionMeta(ctrl)
+	dbMock.MockResponseMeta = NewMockResponseMeta(ctrl)
+
+	return dbMock
+}


### PR DESCRIPTION
不要な構造体が含まれてしまい、test時にしか必要ない`go generate`で生成されるコードに依存するファイルがないとbuildが通らなくなっていた。
tagを使ってこの構造体をbuild時に除外できるようにした。
これによってmockも動くようになるはず。