### PR TITLE
mock立ち上げ方法の記述の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@ OpenAPI Generatorにより、openapiディレクトリ内にルーティング�
 
 ### Mockの起動
 ドライブの[traP Collectionのフォルダ](https://drive.trap.jp/f/399071)にある`collection-mock`内のデータを`upload`ディレクトリへ移したあと、
+`.env`ファイルに
 ```
-$ sh mockgen.sh
+CLIENT_ID={{traQのClientのClientID}}
+CLIENT_SECRET={{traQのClientのClientSecret}}
 ```
-で動きます。
+のように書き、
+```
+$ sudo COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker/mock/docker-compose.yml up
+```
+をすると動きます。
 
 ### コードの生成
 最初にする必要があります。

--- a/mockgen.sh
+++ b/mockgen.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/bash
-sudo COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker/mock/docker-compose.yml up
-sudo docker-compose -f docker/mock/docker-compose.yml down


### PR DESCRIPTION
`.env`の話が抜け落ちていたので加えた。
また、以前と違って今はdocker-composeのみで起動できるようになっており、わざわざシェルスクリプトを使う必要性もなくなったので、`mockgen.sh`を削除してREADMEの立ち上げ方法も変えた。