### PR TITLE
集会を踏まえてのOpenAPI修正

### DIFF
--- a/docs/swagger/openapi.yml
+++ b/docs/swagger/openapi.yml
@@ -318,26 +318,6 @@ paths:
                 format: binary
         500:
           description: 失敗
-  /games/maintainers:
-    get:
-      tags:
-        - game
-      summary: 自分がバージョン更新権限保持者のゲームの取得
-      security: 
-        - TrapMemberAuth:
-          - read
-      operationId: getMyGames
-      responses:
-        200:
-          description: 成功
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Game'
-        500:
-          description: 失敗
   /games/maintainers/{gameID}:
     parameters:
       - $ref: '#/components/parameters/gameID'

--- a/docs/swagger/openapi.yml
+++ b/docs/swagger/openapi.yml
@@ -318,7 +318,7 @@ paths:
                 format: binary
         500:
           description: 失敗
-  /games/maintainers/{gameID}:
+  /games/{gameID}/maintainers:
     parameters:
       - $ref: '#/components/parameters/gameID'
     post:
@@ -372,7 +372,7 @@ paths:
                       type: integer
         500:
           description: 失敗
-  /games/version/{gameID}:
+  /games/{gameID}/version:
     parameters:
       - $ref: '#/components/parameters/gameID'
     post:


### PR DESCRIPTION
集会で指摘された
- GET /games/maintainersがいらない
- /games/maintainer/{{gameID}}という名前が不自然

の修正