### PR TITLE
openapiが上書きされる問題修正

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,6 @@ mysql/data
 docs
 docker
 !docs/swagger/openapi.yml
+!.realize.yaml
 openapi
 mock

--- a/.realize.yaml
+++ b/.realize.yaml
@@ -18,5 +18,8 @@ schema:
       paths:
         - ./router
         - ./model
+        - ./storage
+        - ./session
+        - ./main.go
       ignored_paths:
         - vender

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -33,10 +33,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 WORKDIR /go/src/github.com/traPtitech/trap-collection-server
 
+RUN mkdir upload
+
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod/cache \
   go mod download
 
 COPY --from=generate /local/openapi ./openapi
+COPY .realize.yaml ./
 
 ENTRYPOINT dockerize -wait tcp://mariadb:3306 realize start --name='server' --install --run

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -6,7 +6,11 @@ services:
       dockerfile: ./docker/dev/Dockerfile
     restart: always
     volumes:
-      - ../../:/go/src/github.com/traPtitech/trap-collection-server
+      - ../../model/:/go/src/github.com/traPtitech/trap-collection-server/model
+      - ../../router/:/go/src/github.com/traPtitech/trap-collection-server/router
+      - ../../storage/:/go/src/github.com/traPtitech/trap-collection-server/storage
+      - ../../session/:/go/src/github.com/traPtitech/trap-collection-server/session
+      - ../../main.go:/go/src/github.com/traPtitech/trap-collection-server/main.go
     environment:
       COLLECTION_ENV: development
       OS_AUTH_URL: https://identity.tyo2.conoha.io/v2.0


### PR DESCRIPTION
devの起動時にローカルにopenapiディレクトリがあると、volumeのマウント時にopenapiディレクトリが上書きされていたもんだいをなおした。
これでopenapiの変更時に毎回コード生成をしないでも良くなるはず。