### PR TITLE
席管理・ランチャーの権限管理修正(docs)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -55,24 +55,46 @@
 | created_at | datetime | NO |  | CURRENT_TIMESTAMP |  |  |
 | deleted_at | datetime |  |  | NULL |  |  |
 
-### product_key
-| Name | Type | Null | Key | Default | Extra | 説明 |
-| --- | --- | --- | --- | --- | --- | --- |
-| id | int(11) | NO | PRI |  | AUTO_INCREMENT,unsigned |  |
-| key | varchar(36) | NO | UNI |  |  |  |
-| launcher_version_id | int(11) | NO | MUL |  |  |  |
-| used | boolean | NO |  | false |  | access_tokenが使用済みかどうか |
-
 ### game_version_relations
 | Name | Type | Null | Key | Default | Extra | 説明 |
 | --- | --- | --- | --- | --- | --- | --- |
 | launcher_version_id | int(11) | NO | MUL |  |  |  |
 | game_id | varchar(36) | NO | MUL |  |  |  |
 
-### players
+### product_keys
 | Name | Type | Null | Key | Default | Extra | 説明 |
 | --- | --- | --- | --- | --- | --- | --- |
 | id | int(11) | NO | PRI |  | AUTO_INCREMENT,unsigned |  |
-| product_key_id | int(11) | NO | MUL |  |  |  |
+| key | char(29) | NO | UNI |  |  |  |
+| launcher_version_id | int(11) | NO | MUL |  |  |  |
+| created_at | datetime | NO |  |  |  |  |
+| deleted_at | datetime |  |  | NULL |  |  |
+
+### access_tokens
+| Name | Type | Null | Key | Default | Extra | 説明 |
+| --- | --- | --- | --- | --- | --- | --- |
+| id | int(11) | NO | PRI |  | AUTO_INCREMENT,unsigned |  |
+| key_id | varchar(36) | NO | MUL |  |  |  |
+| access_token | varchar(36) | NO | UNI |  |  |  |
+| refresh_token | varchar(36) | NO | UNI |  |  |  |
+| refresh_enabled | bool | NO |  | true |  |  |
+| expires_in | int(11) | NO |  |  |  |  |
+| created_at | datetime | NO |  |  |  |  |
+| deleted_at | datetime |  |  | NULL |  |  |
+
+### seat_versions
+| Name | Type | Null | Key | Default | Extra | 説明 |
+| --- | --- | --- | --- | --- | --- | --- |
+| id | int(11) | NO | PRI |  | AUTO_INCREMENT,unsigned |  |
+| launcher_version_id | int(11) | NO | MUL |  |  |  |
+| created_at | datetime | NO |  | CURRENT_TIMESTAMP |  |  |
+| deleted_at | datetime |  |  | NULL |  |  |
+
+### seats
+| Name | Type | Null | Key | Default | Extra | 説明 |
+| --- | --- | --- | --- | --- | --- | --- |
+| id | int(11) | NO | PRI |  | AUTO_INCREMENT,unsigned |  |
+| seat_id | int(11) | NO |  |  |  |  |
+| seat_version_id | int(11) | NO | MUL |  |  |  |
 | started_at | datetime | NO |  | CURRENT_TIMESTAMP |  | 着席時刻 |
 | ended_at | datetime |  |  | NULL |  | 離席時刻 |

--- a/docs/swagger/openapi.yml
+++ b/docs/swagger/openapi.yml
@@ -13,6 +13,7 @@ tags:
   - name: user
   - name: game
   - name: version
+  - name: launcherAuth
   - name: seat
 security:
   - TrapMemberAuth:
@@ -635,6 +636,29 @@ paths:
                 $ref: '#/components/schemas/VersionDetails'
         "500":
           description: 失敗
+  /versions/{launcherVersionID}/keys:
+    parameters:
+      - $ref: '#/components/parameters/launcherVersionID'
+    get:
+      tags:
+        - version
+        - launcherAuth
+      summary: バージョンのプロダクトキー一覧
+      description: バージョンのプロダクトキー一覧
+      security:
+        - TrapMemberAuth:
+            - read
+        - AdminAuth: []
+      operationId: getProductKeys
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductKeyDetail'
+        "500":
+          description: 失敗
   /versions/check:
     get:
       tags:
@@ -658,6 +682,74 @@ paths:
                   $ref: '#/components/schemas/CheckItem'
         "500":
           description: 失敗時のレスポンス
+  /launcher/key/generate:
+    post:
+      tags:
+        - launcherAuth
+      summary: プロダクトキー作成
+      description: プロダクトキー作成
+      security:
+        - TrapMemberAuth:
+            - read
+        - AdminAuth: []
+      operationId: postKeyGenerate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductKeyGen'
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductKey'
+        "500":
+          description: 失敗
+  /launcher/key/{productKeyID}:
+    parameters:
+      - $ref: '#/components/parameters/productKeyID'
+    delete:
+      tags:
+        - launcherAuth
+      summary: プロダクトキー失効
+      description: プロダクトキー失効
+      security:
+        - TrapMemberAuth:
+            - read
+        - AdminAuth: []
+      operationId: deleteProductKey
+      responses:
+        "200":
+          description: 成功
+        "500":
+          description: 失敗
+  /launcher/login:
+    post:
+      tags:
+        - launcherAuth
+      summary: ランチャーのログイン
+      description: ランチャーのログイン
+      operationId: postLauncherLogin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductKey'
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LauncherAuthToken'
+        "500":
+          description: 失敗
   /seats/{seatID}:
     parameters:
       - $ref: '#/components/parameters/seatID'
@@ -846,6 +938,14 @@ components:
       required: true
       schema:
         type: string
+    productKeyID:
+      description: productKeyのID
+      name: productKeyID
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
     seatID:
       description: 席のID
       name: seatID
@@ -1206,3 +1306,61 @@ components:
         - name
         - games
         - createdAt
+    ProductKeyGen:
+      description: プロダクトキー生成のリクエスト
+      type: object
+      properties:
+        num:
+          type: integer
+          example: 20
+        version:
+          description: バージョンID
+          type: integer
+          example: 0
+      required:
+        - num
+        - version
+    ProductKey:
+      description: プロダクトキー
+      type: object
+      properties:
+        key:
+          description: プロダクトキー
+          type: string
+          pattern: '^[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}'
+          example: xxxxx-xxxxx-xxxxx-xxxxx-xxxxx
+      required:
+        - key
+    ProductKeyDetail:
+      description: プロダクトキーの詳細
+      type: object
+      properties:
+        id:
+          description: プロダクトキーのID
+          type: string
+          format: uuid
+        key:
+          description: プロダクトキー
+          type: string
+          pattern: '^[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}'
+          example: xxxxx-xxxxx-xxxxx-xxxxx-xxxxx
+      required:
+        - key
+    LauncherAuthToken:
+      description: ランチャーのトークン
+      type: object
+      properties:
+        accessToken:
+          type: string
+          maxLength: 36
+          minLength: 36
+          pattern: '[0-9a-zA-Z]{36}'
+        expiresIn:
+          description: アクセストークンの持続時間(秒)
+          type: integer
+          example: 3600
+        refreshToken:
+          type: string
+          maxLength: 36
+          minLength: 36
+          pattern: '[0-9a-zA-Z]{36}'

--- a/docs/swagger/openapi.yml
+++ b/docs/swagger/openapi.yml
@@ -1394,6 +1394,10 @@ components:
           maxLength: 36
           minLength: 36
           pattern: '[0-9a-zA-Z]{36}'
+      required:
+        - accessToken
+        - expiresIn
+        - refreshToken
     SeatVersion:
       description: 席のバージョン
       type: object

--- a/docs/swagger/openapi.yml
+++ b/docs/swagger/openapi.yml
@@ -14,6 +14,7 @@ tags:
   - name: game
   - name: version
   - name: launcherAuth
+  - name: seatVersion
   - name: seat
 security:
   - TrapMemberAuth:
@@ -641,7 +642,6 @@ paths:
       - $ref: '#/components/parameters/launcherVersionID'
     get:
       tags:
-        - version
         - launcherAuth
       summary: バージョンのプロダクトキー一覧
       description: バージョンのプロダクトキー一覧
@@ -657,6 +657,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProductKeyDetail'
+        "500":
+          description: 失敗
+  /versions/{launcherVersionID}/seats:
+    parameters:
+      - $ref: '#/components/parameters/launcherVersionID'
+    post:
+      tags:
+        - seatVersion
+      summary: バージョンに席のバージョン追加
+      description: バージョンに席のバージョン追加
+      security:
+        - TrapMemberAuth:
+            - read
+        - AdminAuth: []
+      operationId: postSeatVersion
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SeatVersion'
         "500":
           description: 失敗
   /versions/check:
@@ -750,38 +772,9 @@ paths:
                 $ref: '#/components/schemas/LauncherAuthToken'
         "500":
           description: 失敗
-  /seats/{seatID}:
+  /seats/versions/{seatVersionID}:
     parameters:
-      - $ref: '#/components/parameters/seatID'
-    post:
-      tags:
-        - seat
-      summary: 着席
-      description: 着席
-      security:
-        - TrapMemberAuth:
-            - read
-      operationId: postFixSeat
-      responses:
-        "200":
-          description: 成功
-        "500":
-          description: 失敗
-    delete:
-      tags:
-        - seat
-      summary: 離席
-      description: 離席
-      security:
-        - TrapMemberAuth:
-            - read
-      operationId: deleteFixSeat
-      responses:
-        "200":
-          description: 成功
-        "500":
-          description: 失敗
-  /seats:
+      - $ref: '#/components/parameters/seatVersionID'
     get:
       tags:
         - seat
@@ -790,20 +783,34 @@ paths:
       security:
         - TrapMemberAuth:
             - read
-      operationId: getSeat
+      operationId: getSeats
       responses:
         "200":
           description: 成功
           content:
             application/json:
               schema:
-                description: 状態inの席の一覧を取得します。
                 type: array
                 items:
-                  type: integer
-                  description: 埋まっている席のIDの一覧
+                  $ref: '#/components/schemas/SeatDetail'
         "500":
           description: 失敗
+    delete:
+      tags:
+        - seatVersion
+      summary: 席のバージョン消去
+      description: 席のバージョン消去
+      security:
+        - TrapMemberAuth:
+            - read
+        - AdminAuth: []
+      operationId: deleteSeatVersion
+      responses:
+        "200":
+          description: 成功
+        "500":
+          description: 失敗
+  /seats:
     post:
       tags:
         - seat
@@ -812,11 +819,19 @@ paths:
       security:
         - LauncherAuth: []
       operationId: postSeat
-      parameters:
-        - $ref: '#/components/parameters/sessions'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Seat'
       responses:
         "200":
           description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SeatDetail'
         "500":
           description: 失敗
     delete:
@@ -827,11 +842,19 @@ paths:
       security:
         - LauncherAuth: []
       operationId: deleteSeat
-      parameters:
-        - $ref: '#/components/parameters/sessions'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Seat'
       responses:
         "200":
           description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SeatDetail'
         "500":
           description: 失敗
 
@@ -946,6 +969,13 @@ components:
       schema:
         type: string
         format: uuid
+    seatVersionID:
+      description: 席のバージョンのID
+      name: seatVersionID
+      in: path
+      required: true
+      schema:
+        type: integer
     seatID:
       description: 席のID
       name: seatID
@@ -1364,3 +1394,49 @@ components:
           maxLength: 36
           minLength: 36
           pattern: '[0-9a-zA-Z]{36}'
+    SeatVersion:
+      description: 席のバージョン
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 0
+        createdAt:
+          description: 作成時刻
+          type: string
+          format: date-time
+          example: '2019-09-25T09:51:31Z'
+      required:
+        - id
+        - createdAt
+    Seat:
+      description: 席
+      type: object
+      properties:
+        seatVersionId:
+          type: integer
+          example: 0
+        seatId:
+          type: integer
+          example: 0
+      required:
+        - seatVersionId
+        - seatId
+    SeatDetail:
+      description: 席の詳細
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 0
+        status:
+          description: 席の状態(0で離席、1で着席)
+          type: integer
+        SeatingTime:
+          description: 着席時刻
+          type: string
+          format: date-time
+          example: '2019-09-25T09:51:31Z'
+      required:
+        - id
+        - status

--- a/router/seat.go
+++ b/router/seat.go
@@ -1,9 +1,6 @@
 package router
 
 import (
-	"fmt"
-
-	echo "github.com/labstack/echo/v4"
 	"github.com/traPtitech/trap-collection-server/model"
 	"github.com/traPtitech/trap-collection-server/openapi"
 	"github.com/traPtitech/trap-collection-server/router/base"
@@ -26,7 +23,7 @@ func newSeat(db model.DBMeta, launcherAuth base.LauncherAuth) openapi.SeatApi {
 }
 
 // PostSeat POST /seats の処理部分
-func (s *Seat) PostSeat(c echo.Context) error {
+/*func (s *Seat) PostSeat(c echo.Context) error {
 	productKey, err := s.launcherAuth.GetProductKey(c)
 	if err != nil {
 		return fmt.Errorf("Failed In Getting ProductKey: %w", err)
@@ -38,10 +35,10 @@ func (s *Seat) PostSeat(c echo.Context) error {
 	}
 
 	return nil
-}
+}*/
 
 // DeleteSeat DELETE /seats の処理部分
-func (s *Seat) DeleteSeat(c echo.Context) error {
+/*func (s *Seat) DeleteSeat(c echo.Context) error {
 	productKey, err := s.launcherAuth.GetProductKey(c)
 	if err != nil {
 		return fmt.Errorf("Failed In Getting ProductKey")
@@ -53,4 +50,4 @@ func (s *Seat) DeleteSeat(c echo.Context) error {
 	}
 
 	return nil
-}
+}*/


### PR DESCRIPTION
席管理・ランチャーの権限管理修正をDB Schema、OpenAPIに反映させた。
既存の席管理関係のコードでコード生成と干渉してしまうものはコメントアウトしている。
認証は
1. 管理者用UIからプロダクトキー発行(同時に複数個発行可能)
2. 販売時にプロダクトキーを渡す
3. ランチャーでプロダクトキーを用いてログインし、期限付きのアクセストークン取得
4. ランチャーはアクセストークンを用いてエンドポイントを叩く

の流れ。
席管理は
1. 管理者用UIからランチャーバージョンに紐付いた席バージョン作成
2. 各ランチャーに席バージョンと席番号を設定
3. ランチャーは着席・離席エンドポイントをそれを用いて叩く

の流れ。席バージョンの作成がないと販売するランチャーで着席・離席エンドポイントが叩かれる可能性があるためこのような流れになっている。