### PR TITLE
bearer tokenに修正

### DIFF
--- a/docs/swagger/openapi.yml
+++ b/docs/swagger/openapi.yml
@@ -887,7 +887,7 @@ components:
     LauncherAuth:
       type: http
       description: ランチャーの認証
-      scheme: basic
+      scheme: bearer
   parameters:
     sessions:
       name: sessions


### PR DESCRIPTION
ランチャーの認証方式はBearerの方が表記として適切なので修正。