### PR TITLE
クエリパラメーターoperatingSystemを修正

### DIFF
--- a/docs/swagger/openapi.yml
+++ b/docs/swagger/openapi.yml
@@ -915,7 +915,7 @@ components:
         type: integer
     operatingSystem:
       name: operatingSystem
-      description: osのパラメーター(mac,windows)
+      description: osのパラメーター(win32,darwin)
       in: query
       required: true
       schema:

--- a/model/game_versions.go
+++ b/model/game_versions.go
@@ -31,6 +31,13 @@ type GameVersionMeta interface {
 
 // GetGameType ゲームの種類の取得
 func (*DB) GetGameType(gameID string, operatingSystem string) (string, error) {
+	switch operatingSystem {
+	case "win32":
+		operatingSystem = "windows"
+	case "darwin":
+		operatingSystem = "mac"
+	}
+
 	intOs, ok := osGameTypeIntMap[operatingSystem]
 	if !ok {
 		return "", errors.New("Invalid OS Error")

--- a/router/game.go
+++ b/router/game.go
@@ -150,6 +150,13 @@ func (g *Game) DeleteGames(gameID string) error {
 
 // GetGameFile GET /games/asset/:gameID/fileの処理部分
 func (g *Game) GetGameFile(gameID string, operatingSystem string) (io.Reader, error) {
+	switch operatingSystem {
+	case "win32":
+		operatingSystem = "windows"
+	case "darwin":
+		operatingSystem = "mac"
+	}
+
 	fileName, err := g.getGameFileName(gameID, operatingSystem)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get file name: %w", err)


### PR DESCRIPTION
windows,macを取れるようにしていたが、Nodejsの`process.platform`に合わせてwin32,darwinにした。