### PR TITLE
mock/dbのpackage名修正

### DIFF
--- a/src/repository/mock/db.go
+++ b/src/repository/mock/db.go
@@ -1,4 +1,4 @@
-package repository
+package mock
 
 import (
 	context "context"


### PR DESCRIPTION
パッケージ名がrepositoryになっており、src/repositoryと紛らわしいのでmocuに変更。