### PR TITLE
middlewareのランチャー認証対応

### DIFF
--- a/src/handler/v1/context.go
+++ b/src/handler/v1/context.go
@@ -1,0 +1,41 @@
+package v1
+
+import (
+	"errors"
+
+	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+)
+
+const (
+	launcherUserKey    = "launcherUser"
+	launcherVersionKey = "launcherVersion"
+)
+
+func getLauncherUser(c echo.Context) (*domain.LauncherUser, error) {
+	iLauncherUser := c.Get(launcherUserKey)
+	if iLauncherUser == nil {
+		return nil, errors.New("launcher user is not set")
+	}
+
+	launcherUser, ok := iLauncherUser.(*domain.LauncherUser)
+	if !ok {
+		return nil, errors.New("invalid launcher user")
+	}
+
+	return launcherUser, nil
+}
+
+func getLauncherVersion(c echo.Context) (*domain.LauncherVersion, error) {
+	iLauncherVersion := c.Get(launcherVersionKey)
+	if iLauncherVersion == nil {
+		return nil, errors.New("launcher version is not set")
+	}
+
+	launcherVersion, ok := iLauncherVersion.(*domain.LauncherVersion)
+	if !ok {
+		return nil, errors.New("invalid launcher version")
+	}
+
+	return launcherVersion, nil
+}

--- a/src/handler/v1/middleware.go
+++ b/src/handler/v1/middleware.go
@@ -1,6 +1,15 @@
 package v1
 
-import "github.com/traPtitech/trap-collection-server/src/service"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/service"
+)
 
 type Middleware struct {
 	launcherAuthService service.LauncherAuth
@@ -10,4 +19,51 @@ func NewMiddleware(launcherAuthService service.LauncherAuth) *Middleware {
 	return &Middleware{
 		launcherAuthService: launcherAuthService,
 	}
+}
+
+func (m *Middleware) LauncherAuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		ok, err := m.CheckLauncherAuth(c)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusUnauthorized, err.Error())
+		}
+
+		if !ok {
+			return echo.NewHTTPError(http.StatusUnauthorized, "invalid launcher auth")
+		}
+
+		return next(c)
+	}
+}
+
+// 旧実装でも使えるように大文字で定義している
+func (m *Middleware) CheckLauncherAuth(c echo.Context) (bool, error) {
+	authorizationHeader := c.Request().Header.Get(echo.HeaderAuthorization)
+
+	if !strings.HasPrefix(authorizationHeader, "Bearer ") {
+		return false, fmt.Errorf("invalid authorization header: %s", authorizationHeader)
+	}
+
+	strAccessToken := strings.TrimPrefix(authorizationHeader, "Bearer ")
+	accessToken := values.NewLauncherSessionAccessTokenFromString(strAccessToken)
+	err := accessToken.Validate()
+	if err != nil {
+		return false, fmt.Errorf("invalid access token: %w", err)
+	}
+
+	launcherUser, launcherVersion, err := m.launcherAuthService.LauncherAuth(c.Request().Context(), accessToken)
+	if errors.Is(err, service.ErrInvalidLauncherSessionAccessToken) {
+		return false, fmt.Errorf("invalid access token: %w", err)
+	}
+	if errors.Is(err, service.ErrLauncherSessionAccessTokenExpired) {
+		return false, fmt.Errorf("access token expired: %w", err)
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to check launcher auth: %w", err)
+	}
+
+	c.Set(launcherUserKey, launcherUser)
+	c.Set(launcherVersionKey, launcherVersion)
+
+	return true, nil
 }

--- a/src/handler/v1/middleware.go
+++ b/src/handler/v1/middleware.go
@@ -1,0 +1,13 @@
+package v1
+
+import "github.com/traPtitech/trap-collection-server/src/service"
+
+type Middleware struct {
+	launcherAuthService service.LauncherAuth
+}
+
+func NewMiddleware(launcherAuthService service.LauncherAuth) *Middleware {
+	return &Middleware{
+		launcherAuthService: launcherAuthService,
+	}
+}

--- a/src/handler/v1/middleware_test.go
+++ b/src/handler/v1/middleware_test.go
@@ -1,0 +1,167 @@
+package v1
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/service"
+	"github.com/traPtitech/trap-collection-server/src/service/mock"
+)
+
+func TestCheckLauncherAuth(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
+
+	middleware := NewMiddleware(mockLauncherAuthService)
+
+	type test struct {
+		description         string
+		authorizationHeader string
+		executeLauncherAuth bool
+		accessToken         values.LauncherSessionAccessToken
+		launcherUser        *domain.LauncherUser
+		launcherVersion     *domain.LauncherVersion
+		LauncherAuthErr     error
+		setValues           bool
+		ok                  bool
+		isErr               bool
+		err                 error
+	}
+
+	accessToken, err := values.NewLauncherSessionAccessToken()
+	if err != nil {
+		t.Errorf("failed to create access token: %v", err)
+	}
+
+	productKey1, err := values.NewLauncherUserProductKey()
+	if err != nil {
+		t.Errorf("failed to create product key: %v", err)
+	}
+
+	testCases := []test{
+		{
+			description:         "Authorizationヘッダーが空文字なのでエラー",
+			authorizationHeader: "",
+			ok:                  false,
+			isErr:               true,
+		},
+		{
+			description:         "AuthorizationヘッダーがBearerトークンでないのでエラー",
+			authorizationHeader: "Basic",
+			ok:                  false,
+			isErr:               true,
+		},
+		{
+			description:         "accessTokenの形式が不正なのでエラー",
+			authorizationHeader: "Bearer a",
+			ok:                  false,
+			isErr:               true,
+		},
+		{
+			description:         "accessTokenが空文字なのでエラー",
+			authorizationHeader: "Bearer ",
+			ok:                  false,
+			isErr:               true,
+		},
+		{
+			description:         "LauncherAuthがErrInvalidLauncherSessionAccessTokenなのでエラー",
+			authorizationHeader: "Bearer " + string(accessToken),
+			executeLauncherAuth: true,
+			accessToken:         accessToken,
+			LauncherAuthErr:     service.ErrInvalidLauncherSessionAccessToken,
+			ok:                  false,
+			isErr:               true,
+		},
+		{
+			description:         "LauncherAuthがErrLauncherSessionAccessTokenExpiredなのでエラー",
+			authorizationHeader: "Bearer " + string(accessToken),
+			executeLauncherAuth: true,
+			accessToken:         accessToken,
+			LauncherAuthErr:     service.ErrLauncherSessionAccessTokenExpired,
+			ok:                  false,
+			isErr:               true,
+		},
+		{
+			description:         "LauncherAuthがエラーなのでエラー",
+			authorizationHeader: "Bearer " + string(accessToken),
+			executeLauncherAuth: true,
+			accessToken:         accessToken,
+			LauncherAuthErr:     errors.New("error"),
+			ok:                  false,
+			isErr:               true,
+		},
+		{
+			description:         "LauncherAuthが成功",
+			authorizationHeader: "Bearer " + string(accessToken),
+			executeLauncherAuth: true,
+			accessToken:         accessToken,
+			launcherUser: domain.NewLauncherUser(
+				values.NewLauncherUserID(),
+				productKey1,
+			),
+			launcherVersion: domain.NewLauncherVersionWithoutQuestionnaire(
+				values.NewLauncherVersionID(),
+				values.NewLauncherVersionName("test"),
+				time.Now(),
+			),
+			setValues: true,
+			ok:        true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			req.Header.Set(echo.HeaderAuthorization, testCase.authorizationHeader)
+
+			if testCase.executeLauncherAuth {
+				mockLauncherAuthService.
+					EXPECT().
+					LauncherAuth(c.Request().Context(), testCase.accessToken).
+					Return(testCase.launcherUser, testCase.launcherVersion, testCase.LauncherAuthErr)
+			}
+
+			ok, err := middleware.CheckLauncherAuth(c)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, testCase.ok, ok)
+
+			if testCase.setValues {
+				launcherUser, err := getLauncherUser(c)
+				assert.NoError(t, err)
+				assert.Equal(t, testCase.launcherUser, launcherUser)
+
+				launcherVersion, err := getLauncherVersion(c)
+				assert.NoError(t, err)
+				assert.Equal(t, testCase.launcherVersion, launcherVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#138 でmiddlewareの対応を忘れていたので対応した。
旧Middlewareの実装とうまく混ぜる必要があったので、旧Middlewareに新Middlewareをembedするというちょっと複雑な形になっている。