### PR TITLE
securityが壊れていた問題修正

### DIFF
--- a/docs/swagger/openapi.yml
+++ b/docs/swagger/openapi.yml
@@ -16,10 +16,6 @@ tags:
   - name: launcherAuth
   - name: seatVersion
   - name: seat
-security:
-  - TrapMemberAuth:
-      - read
-  - LauncherAuth: []
 paths:
   /oauth2/callback:
     parameters:


### PR DESCRIPTION
OpenAPI Generatorでopenapiのsecurityを設定すると全エンドポイントのデフォルトとなるようになっていて(おそらくこちらが正しい挙動)、
生成コードの認証が壊れていたので修正した。