### PR TITLE
旧migrateでcharset指定

### DIFF
--- a/model/db.go
+++ b/model/db.go
@@ -55,6 +55,8 @@ func EstablishDB() (*gorm.DB, error) {
 
 // Migrate DBのマイグレーション
 func Migrate(env string) error {
+	db.Set("gorm:table_options", "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci")
+
 	err := db.AutoMigrate(allTables...).Error
 	if err != nil {
 		return fmt.Errorf("Failed In Migration:%w", err)


### PR DESCRIPTION
charsetの指定がない結果、旧migrateでmigrateされるテーブルと新migrateでmigrateされるテーブルでcharsetが違くなって外部キー制約を張れなくなっていた。