### PR TITLE
sessionの保存場所をcookieに

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       DB_HOSTNAME: mariadb
       DB_PORT: 3306
       DB_DATABASE: trap_collection
+      SESSION_SECRET: secret
       PORT: :3000
     ports: 
       - 3000:3000

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/labstack/echo-contrib v0.9.0
 	github.com/labstack/echo/v4 v4.1.16
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
-	github.com/srinathgs/mysqlstore v0.0.0-20200417050510-9cbb9420fc4c
 	github.com/stretchr/testify v1.4.0
 	github.com/t-tiger/gorm-bulk-insert v1.3.0
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
-github.com/srinathgs/mysqlstore v0.0.0-20200417050510-9cbb9420fc4c h1:HT6QRF79dL2Ed6HCrX9RufkxFGo7+NPkgYF1Uzvv/js=
-github.com/srinathgs/mysqlstore v0.0.0-20200417050510-9cbb9420fc4c/go.mod h1:kt46Hd+lF0rtpeRgOvYSWYJItOAd73EKkIBZFbX7TXs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/main.go
+++ b/main.go
@@ -45,7 +45,12 @@ func main() {
 		panic(err)
 	}
 
-	sess, err := sess.NewSession(db.DB())
+	secret, ok := os.LookupEnv("SESSION_SECRET")
+	if !ok {
+		panic("SESSION_SECRET is not set")
+	}
+
+	sess, err := sess.NewSession(secret)
 	if err != nil {
 		panic(fmt.Errorf("Failed In Session Constructor: %w", err))
 	}


### PR DESCRIPTION
リクエストが来ていないときにRevokeする必要などもなく、cookie利用の方がhandlerでDBを触るような面倒なことを回避できるため、cookieへ暗号化して保存する方式に変更した。
また、secretを環境変数から読み込んだものに変更している。