### PR TITLE
新アーキテクチャ用のセッション基盤作成

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -3,7 +3,9 @@ package common
 import "net/url"
 
 type (
-	IsProduction bool
-	ClientID     string
-	TraQBaseURL  *url.URL
+	IsProduction  bool
+	ClientID      string
+	TraQBaseURL   *url.URL
+	SessionSecret string
+	SessionKey    string
 )

--- a/src/handler/v1/api.go
+++ b/src/handler/v1/api.go
@@ -3,11 +3,13 @@ package v1
 type API struct {
 	*Middleware
 	*LauncherAuth
+	*Session
 }
 
-func NewAPI(launcherAuth *LauncherAuth, middleware *Middleware) *API {
+func NewAPI(launcherAuth *LauncherAuth, middleware *Middleware, session *Session) *API {
 	return &API{
 		LauncherAuth: launcherAuth,
 		Middleware:   middleware,
+		Session:      session,
 	}
 }

--- a/src/handler/v1/session.go
+++ b/src/handler/v1/session.go
@@ -37,3 +37,12 @@ func (s *Session) getSession(c echo.Context) (*sessions.Session, error) {
 
 	return session, nil
 }
+
+func (s *Session) save(c echo.Context, session *sessions.Session) error {
+	err := s.store.Save(c.Request(), c.Response(), session)
+	if err != nil {
+		return fmt.Errorf("failed to save session: %w", err)
+	}
+
+	return nil
+}

--- a/src/handler/v1/session.go
+++ b/src/handler/v1/session.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"fmt"
+
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
@@ -25,4 +27,13 @@ func NewSession(key common.SessionKey, secret common.SessionSecret) *Session {
 
 func (s *Session) Use(e *echo.Echo) {
 	e.Use(session.Middleware(s.store))
+}
+
+func (s *Session) getSession(c echo.Context) (*sessions.Session, error) {
+	session, err := s.store.Get(c.Request(), s.key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get session: %w", err)
+	}
+
+	return session, nil
 }

--- a/src/handler/v1/session.go
+++ b/src/handler/v1/session.go
@@ -1,16 +1,10 @@
 package v1
 
 import (
-	"errors"
-	"fmt"
-	"time"
-
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
 	"github.com/traPtitech/trap-collection-server/pkg/common"
-	"github.com/traPtitech/trap-collection-server/src/domain"
-	"github.com/traPtitech/trap-collection-server/src/domain/values"
 )
 
 type Session struct {
@@ -33,7 +27,7 @@ func (s *Session) Use(e *echo.Echo) {
 	e.Use(session.Middleware(s.store))
 }
 
-func (s *Session) getSession(c echo.Context) (*sessions.Session, error) {
+/*func (s *Session) getSession(c echo.Context) (*sessions.Session, error) {
 	session, err := s.store.Get(c.Request(), s.key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session: %w", err)
@@ -111,4 +105,4 @@ func (s *Session) getAccessToken(session *sessions.Session) (*domain.OIDCSession
 		values.NewOIDCAccessToken(accessToken),
 		expiresAt,
 	), nil
-}
+}*/

--- a/src/handler/v1/session.go
+++ b/src/handler/v1/session.go
@@ -1,0 +1,22 @@
+package v1
+
+import (
+	"github.com/gorilla/sessions"
+	"github.com/traPtitech/trap-collection-server/pkg/common"
+)
+
+type Session struct {
+	key    string
+	secret string
+	store  sessions.Store
+}
+
+func NewSession(key common.SessionKey, secret common.SessionSecret) *Session {
+	store := sessions.NewCookieStore([]byte(secret))
+
+	return &Session{
+		key:    string(key),
+		secret: string(secret),
+		store:  store,
+	}
+}

--- a/src/handler/v1/session.go
+++ b/src/handler/v1/session.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"github.com/gorilla/sessions"
+	"github.com/labstack/echo-contrib/session"
+	"github.com/labstack/echo/v4"
 	"github.com/traPtitech/trap-collection-server/pkg/common"
 )
 
@@ -19,4 +21,8 @@ func NewSession(key common.SessionKey, secret common.SessionSecret) *Session {
 		secret: string(secret),
 		store:  store,
 	}
+}
+
+func (s *Session) Use(e *echo.Echo) {
+	e.Use(session.Middleware(s.store))
 }

--- a/src/handler/v1/session.go
+++ b/src/handler/v1/session.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gorilla/sessions"
@@ -45,4 +46,31 @@ func (s *Session) save(c echo.Context, session *sessions.Session) error {
 	}
 
 	return nil
+}
+
+var (
+	ErrNoValue     = errors.New("no value")
+	ErrValueBroken = errors.New("value broken")
+)
+
+const (
+	codeVerifierSessionKey = "codeVerifier"
+)
+
+func (s *Session) setCodeVerifier(session *sessions.Session, codeVerifier string) {
+	session.Values[codeVerifierSessionKey] = codeVerifier
+}
+
+func (s *Session) getCodeVerifier(session *sessions.Session) (string, error) {
+	iCodeVerifier, ok := session.Values[codeVerifierSessionKey]
+	if !ok {
+		return "", ErrNoValue
+	}
+
+	codeVerifier, ok := iCodeVerifier.(string)
+	if !ok {
+		return "", ErrValueBroken
+	}
+
+	return codeVerifier, nil
 }

--- a/src/wire.go
+++ b/src/wire.go
@@ -13,6 +13,12 @@ import (
 	v1Service "github.com/traPtitech/trap-collection-server/src/service/v1"
 )
 
+type Config struct {
+	IsProduction  common.IsProduction
+	SessionKey    common.SessionKey
+	SessionSecret common.SessionSecret
+}
+
 var (
 	dbBind                        = wire.Bind(new(repository.DB), new(*gorm2.DB))
 	launcherSessionRepositoryBind = wire.Bind(new(repository.LauncherSession), new(*gorm2.LauncherSession))
@@ -20,10 +26,17 @@ var (
 	launcherVersionRepositoryBind = wire.Bind(new(repository.LauncherVersion), new(*gorm2.LauncherVersion))
 
 	launcherAuthServiceBind = wire.Bind(new(service.LauncherAuth), new(*v1Service.LauncherAuth))
+
+	isProductionField  = wire.FieldsOf(new(*Config), "IsProduction")
+	sessionKeyField    = wire.FieldsOf(new(*Config), "SessionKey")
+	sessionSecretField = wire.FieldsOf(new(*Config), "SessionSecret")
 )
 
-func InjectAPI(isProduction common.IsProduction) (*v1Handler.API, error) {
+func InjectAPI(config *Config) (*v1Handler.API, error) {
 	wire.Build(
+		isProductionField,
+		sessionKeyField,
+		sessionSecretField,
 		dbBind,
 		launcherSessionRepositoryBind,
 		launcherUserRepositoryBind,
@@ -35,6 +48,7 @@ func InjectAPI(isProduction common.IsProduction) (*v1Handler.API, error) {
 		gorm2.NewLauncherVersion,
 		v1Service.NewLauncherAuth,
 		v1Handler.NewAPI,
+		v1Handler.NewSession,
 		v1Handler.NewLauncherAuth,
 		v1Handler.NewMiddleware,
 	)


### PR DESCRIPTION
セッションの基盤を作った。
旧実装とうまく繋がるようにしているため、新アーキテクチャで設定されたセッションは旧実装でも使えるようになっている。