### PR TITLE
userサービス実装

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/comail/colog v0.0.0-20160416085026-fba8e7b1f46c
-	github.com/dvsekhvalnov/jose2go v0.0.0-20180829124132-7f401d37b68a
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,6 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6RO
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dvsekhvalnov/jose2go v0.0.0-20180829124132-7f401d37b68a h1:mq+R6XEM6lJX5VlLyZIrUSP8tSuJp82xTK89hvBwJbU=
-github.com/dvsekhvalnov/jose2go v0.0.0-20180829124132-7f401d37b68a/go.mod h1:7BvyPhdbLxMXIYTFPLsyJRFMsKmOZnQmzh6Gb+uquuM=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/src/auth/user.go
+++ b/src/auth/user.go
@@ -1,0 +1,15 @@
+package auth
+
+//go:generate mockgen -source=$GOFILE -destination=mock/${GOFILE} -package=mock
+
+import (
+	"context"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/service"
+)
+
+type User interface {
+	GetMe(ctx context.Context, session *domain.OIDCSession) (*service.UserInfo, error)
+	GetAllActiveUsers(ctx context.Context, session *domain.OIDCSession) ([]*service.UserInfo, error)
+}

--- a/src/cache/errors.go
+++ b/src/cache/errors.go
@@ -1,0 +1,7 @@
+package cache
+
+import "errors"
+
+var (
+	ErrCacheMiss = errors.New("cache: key not found")
+)

--- a/src/cache/user.go
+++ b/src/cache/user.go
@@ -1,0 +1,15 @@
+package cache
+
+//go:generate mockgen -source=$GOFILE -destination=mock/${GOFILE} -package=mock
+
+import (
+	"context"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/service"
+)
+
+type User interface {
+	GetMe(ctx context.Context, session *domain.OIDCSession) (*service.UserInfo, error)
+	GetAllActiveUsers(ctx context.Context) ([]*service.UserInfo, error)
+}

--- a/src/cache/user.go
+++ b/src/cache/user.go
@@ -6,10 +6,13 @@ import (
 	"context"
 
 	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/service"
 )
 
 type User interface {
-	GetMe(ctx context.Context, session *domain.OIDCSession) (*service.UserInfo, error)
+	GetMe(ctx context.Context, accessToken values.OIDCAccessToken) (*service.UserInfo, error)
+	SetMe(ctx context.Context, session *domain.OIDCSession, user *service.UserInfo) error
 	GetAllActiveUsers(ctx context.Context) ([]*service.UserInfo, error)
+	SetAllActiveUsers(ctx context.Context, users []*service.UserInfo) error
 }

--- a/src/domain/values/trap_member.go
+++ b/src/domain/values/trap_member.go
@@ -37,11 +37,7 @@ const (
 	TrapMemberRoleAdmin
 )
 
-func NewTrapMemberID() TraPMemberID {
-	return TraPMemberID(uuid.New())
-}
-
-func NewTrapMemberIDFromUUID(id uuid.UUID) TraPMemberID {
+func NewTrapMemberID(id uuid.UUID) TraPMemberID {
 	return TraPMemberID(id)
 }
 

--- a/src/service/user.go
+++ b/src/service/user.go
@@ -1,0 +1,42 @@
+package service
+
+//go:generate mockgen -source=$GOFILE -destination=mock/${GOFILE} -package=mock
+
+import (
+	"context"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
+
+type User interface {
+	GetMe(ctx context.Context, session *domain.OIDCSession) (*UserInfo, error)
+	GetAllActiveUser(ctx context.Context, session *domain.OIDCSession) ([]*UserInfo, error)
+}
+
+// UserInfo 簡易的なtraP部員の情報
+type UserInfo struct {
+	id     values.TraPMemberID
+	name   values.TraPMemberName
+	status values.TraPMemberStatus
+}
+
+func NewUserInfo(id values.TraPMemberID, name values.TraPMemberName, status values.TraPMemberStatus) *UserInfo {
+	return &UserInfo{
+		id:     id,
+		name:   name,
+		status: status,
+	}
+}
+
+func (ui *UserInfo) GetID() values.TraPMemberID {
+	return ui.id
+}
+
+func (ui *UserInfo) GetName() values.TraPMemberName {
+	return ui.name
+}
+
+func (ui *UserInfo) GetStatus() values.TraPMemberStatus {
+	return ui.status
+}

--- a/src/service/v1/user.go
+++ b/src/service/v1/user.go
@@ -1,0 +1,18 @@
+package v1
+
+import (
+	"github.com/traPtitech/trap-collection-server/src/auth"
+	"github.com/traPtitech/trap-collection-server/src/cache"
+)
+
+type User struct {
+	userAuth  auth.User
+	userCache cache.User
+}
+
+func NewUser(userAuth auth.User, userCache cache.User) *User {
+	return &User{
+		userAuth:  userAuth,
+		userCache: userCache,
+	}
+}

--- a/src/service/v1/user_test.go
+++ b/src/service/v1/user_test.go
@@ -1,0 +1,131 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	mockAuth "github.com/traPtitech/trap-collection-server/src/auth/mock"
+	"github.com/traPtitech/trap-collection-server/src/cache"
+	mockCache "github.com/traPtitech/trap-collection-server/src/cache/mock"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/service"
+)
+
+func TestGetMe(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockUserCache := mockCache.NewMockUser(ctrl)
+	mockUserAuth := mockAuth.NewMockUser(ctrl)
+
+	userService := NewUser(mockUserAuth, mockUserCache)
+
+	type test struct {
+		description      string
+		cacheUser        *service.UserInfo
+		cacheGetMeErr    error
+		executeAuthGetMe bool
+		authUser         *service.UserInfo
+		authGetMeErr     error
+		cacheSetMeErr    error
+		user             *service.UserInfo
+		isErr            bool
+		err              error
+	}
+
+	user := service.NewUserInfo(
+		values.NewTrapMemberID(uuid.New()),
+		values.NewTrapMemberName("mazrean"),
+		values.TrapMemberStatusActive,
+	)
+
+	testCases := []test{
+		{
+			description: "cacheがhitするのでエラーなし",
+			cacheUser:   user,
+			user:        user,
+		},
+		{
+			description:      "cacheがhitしないがauthからの取り出しに成功するのでエラーなし",
+			cacheGetMeErr:    cache.ErrCacheMiss,
+			executeAuthGetMe: true,
+			authUser:         user,
+			user:             user,
+		},
+		{
+			description:      "cacheがエラー(ErrCacheMiss以外)でもauthからの取り出しに成功するのでエラーなし",
+			cacheGetMeErr:    errors.New("cache error"),
+			executeAuthGetMe: true,
+			authUser:         user,
+			user:             user,
+		},
+		{
+			description:      "cacheがhitせずauthからの取り出しがエラーなのでエラー",
+			cacheGetMeErr:    cache.ErrCacheMiss,
+			executeAuthGetMe: true,
+			authGetMeErr:     errors.New("auth error"),
+			isErr:            true,
+		},
+		{
+			description:      "cacheがhitしないがauthからの取り出しに成功するのでcache設定に失敗してもエラーなし",
+			cacheGetMeErr:    cache.ErrCacheMiss,
+			executeAuthGetMe: true,
+			authUser:         user,
+			cacheSetMeErr:    errors.New("cache error"),
+			user:             user,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			session := domain.NewOIDCSession(
+				values.NewOIDCAccessToken("access token"),
+				time.Now(),
+			)
+
+			mockUserCache.
+				EXPECT().
+				GetMe(ctx, session.GetAccessToken()).
+				Return(testCase.cacheUser, testCase.cacheGetMeErr)
+			if testCase.executeAuthGetMe {
+				mockUserAuth.
+					EXPECT().
+					GetMe(ctx, session).
+					Return(testCase.authUser, testCase.authGetMeErr)
+				if testCase.authGetMeErr == nil {
+					mockUserCache.
+						EXPECT().
+						SetMe(ctx, session, testCase.authUser).
+						Return(testCase.cacheSetMeErr)
+				}
+			}
+
+			user, err := userService.GetMe(ctx, session)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, testCase.user, user)
+		})
+	}
+}


### PR DESCRIPTION
userサービスを実装した。
旧実装では毎回traQにリクエストを飛ばしていたが、新実装ではin-memory cacheを入れてリクエストを飛ばす回数を削る。