### PR TITLE
cacheのテストを直列化

### DIFF
--- a/src/cache/ristretto/user_test.go
+++ b/src/cache/ristretto/user_test.go
@@ -339,10 +339,7 @@ func TestSetAllActiveUsers(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.description, func(t *testing.T) {
-			t.Parallel()
-
 			if testCase.keyExist {
 				ok := userCache.activeUsers.Set(activeUsersKey, testCase.beforeValue, 1)
 				assert.True(t, ok)


### PR DESCRIPTION
テストがうまく並列化できておらず、場合によっては落ちる状態になっていたようなので、直列化した。