### PR TITLE
GameImageサービス実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ main
 mysql/data
 .openapi-generator
 openapi
-mock
+**/mock/*
+!src/storage/mock/game_image.go
+!src/repository/mock/db.go
 !mysql/init/mock
 !docker/mock
 upload/*

--- a/src/repository/game_image.go
+++ b/src/repository/game_image.go
@@ -1,0 +1,15 @@
+package repository
+
+//go:generate mockgen -source=$GOFILE -destination=mock/${GOFILE} -package=mock
+
+import (
+	"context"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
+
+type GameImage interface {
+	SaveGameImage(ctx context.Context, gameID values.GameID, image *domain.GameImage) error
+	GetGameImage(ctx context.Context, gameID values.GameID, lockType LockType) (*domain.GameImage, error)
+}

--- a/src/service/errors.go
+++ b/src/service/errors.go
@@ -16,4 +16,6 @@ var (
 	ErrInvalidGameID                     = errors.New("invalid game id")
 	ErrInvalidUserID                     = errors.New("invalid user id")
 	ErrForbidden                         = errors.New("forbidden")
+	ErrInvalidFormat                     = errors.New("invalid format")
+	ErrNoGameImage                       = errors.New("no game image")
 )

--- a/src/service/game_image.go
+++ b/src/service/game_image.go
@@ -1,0 +1,15 @@
+package service
+
+//go:generate mockgen -source=$GOFILE -destination=mock/${GOFILE} -package=mock
+
+import (
+	"context"
+	"io"
+
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
+
+type GameImage interface {
+	SaveGameImage(ctx context.Context, reader io.Reader, gameID values.GameID) error
+	GetGameImage(ctx context.Context, writer io.Writer, gameID values.GameID) error
+}

--- a/src/service/v1/game_image.go
+++ b/src/service/v1/game_image.go
@@ -1,0 +1,27 @@
+package v1
+
+import (
+	"github.com/traPtitech/trap-collection-server/src/repository"
+	"github.com/traPtitech/trap-collection-server/src/storage"
+)
+
+type GameImage struct {
+	db                  repository.DB
+	gameRepository      repository.Game
+	gameImageRepository repository.GameImage
+	gameImageStorage    storage.GameImage
+}
+
+func NewGameImage(
+	db repository.DB,
+	gameRepository repository.Game,
+	gameImageRepository repository.GameImage,
+	gameImageStorage storage.GameImage,
+) *GameImage {
+	return &GameImage{
+		db:                  db,
+		gameRepository:      gameRepository,
+		gameImageRepository: gameImageRepository,
+		gameImageStorage:    gameImageStorage,
+	}
+}

--- a/src/service/v1/game_image.go
+++ b/src/service/v1/game_image.go
@@ -1,7 +1,18 @@
 package v1
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/h2non/filetype"
+	"github.com/h2non/filetype/matchers"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/repository"
+	"github.com/traPtitech/trap-collection-server/src/service"
 	"github.com/traPtitech/trap-collection-server/src/storage"
 )
 
@@ -24,4 +35,57 @@ func NewGameImage(
 		gameImageRepository: gameImageRepository,
 		gameImageStorage:    gameImageStorage,
 	}
+}
+
+func (gi *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, gameID values.GameID) error {
+	err := gi.db.Transaction(ctx, nil, func(ctx context.Context) error {
+		_, err := gi.gameRepository.GetGame(ctx, gameID, repository.LockTypeRecord)
+		if errors.Is(err, repository.ErrRecordNotFound) {
+			return service.ErrInvalidGameID
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get game: %w", err)
+		}
+
+		buf := bytes.NewBuffer(nil)
+		r := io.TeeReader(reader, buf)
+		fType, err := filetype.MatchReader(r)
+		if err != nil {
+			return fmt.Errorf("failed to get file type: %w", err)
+		}
+
+		var imageType values.GameImageType
+		switch fType.Extension {
+		case matchers.TypeJpeg.Extension:
+			imageType = values.GameImageTypeJpeg
+		case matchers.TypePng.Extension:
+			imageType = values.GameImageTypePng
+		case matchers.TypeGif.Extension:
+			imageType = values.GameImageTypeGif
+		default:
+			return service.ErrInvalidFormat
+		}
+
+		image := domain.NewGameImage(
+			values.NewGameImageID(),
+			imageType,
+		)
+
+		err = gi.gameImageRepository.SaveGameImage(ctx, gameID, image)
+		if err != nil {
+			return fmt.Errorf("failed to save game image: %w", err)
+		}
+
+		err = gi.gameImageStorage.SaveGameImage(ctx, buf, image)
+		if err != nil {
+			return fmt.Errorf("failed to save game image file: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed in transaction: %w", err)
+	}
+
+	return nil
 }

--- a/src/service/v1/game_image_test.go
+++ b/src/service/v1/game_image_test.go
@@ -1,0 +1,202 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/repository"
+	mockRepository "github.com/traPtitech/trap-collection-server/src/repository/mock"
+	"github.com/traPtitech/trap-collection-server/src/service"
+	mockStorage "github.com/traPtitech/trap-collection-server/src/storage/mock"
+)
+
+func TestSaveGameImage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mockRepository.NewMockDB(ctrl)
+	mockGameRepository := mockRepository.NewMockGame(ctrl)
+	mockGameImageRepository := mockRepository.NewMockGameImage(ctrl)
+
+	type test struct {
+		description                    string
+		gameID                         values.GameID
+		isValidFile                    bool
+		imageType                      values.GameImageType
+		GetGameErr                     error
+		executeRepositorySaveGameImage bool
+		RepositorySaveGameImageErr     error
+		executeStorageSaveGameImage    bool
+		StorageSaveGameImageErr        error
+		isErr                          bool
+		err                            error
+	}
+
+	testCases := []test{
+		{
+			description:                    "特に問題ないのでエラーなし",
+			gameID:                         values.NewGameID(),
+			isValidFile:                    true,
+			imageType:                      values.GameImageTypeJpeg,
+			executeRepositorySaveGameImage: true,
+			executeStorageSaveGameImage:    true,
+		},
+		{
+			description: "GetGameがErrRecordNotFoundなのでErrInvalidGameID",
+			gameID:      values.NewGameID(),
+			isValidFile: true,
+			imageType:   values.GameImageTypeJpeg,
+			GetGameErr:  repository.ErrRecordNotFound,
+			isErr:       true,
+			err:         service.ErrInvalidGameID,
+		},
+		{
+			description: "GetGameがエラーなのでエラー",
+			gameID:      values.NewGameID(),
+			isValidFile: true,
+			imageType:   values.GameImageTypeJpeg,
+			GetGameErr:  errors.New("error"),
+			isErr:       true,
+		},
+		{
+			description:                    "画像がpngでもエラーなし",
+			gameID:                         values.NewGameID(),
+			isValidFile:                    true,
+			imageType:                      values.GameImageTypePng,
+			executeRepositorySaveGameImage: true,
+			executeStorageSaveGameImage:    true,
+		},
+		{
+			description:                    "画像がgifでもエラーなし",
+			gameID:                         values.NewGameID(),
+			isValidFile:                    true,
+			imageType:                      values.GameImageTypeGif,
+			executeRepositorySaveGameImage: true,
+			executeStorageSaveGameImage:    true,
+		},
+		{
+			description: "画像が不正なのでエラー",
+			gameID:      values.NewGameID(),
+			isValidFile: false,
+			isErr:       true,
+			err:         service.ErrInvalidFormat,
+		},
+		{
+			description:                    "repository.SaveGameImageがエラーなのでエラー",
+			gameID:                         values.NewGameID(),
+			isValidFile:                    true,
+			imageType:                      values.GameImageTypeJpeg,
+			executeRepositorySaveGameImage: true,
+			RepositorySaveGameImageErr:     errors.New("error"),
+			isErr:                          true,
+		},
+		{
+			description:                    "storage.SaveGameImageがエラーなのでエラー",
+			gameID:                         values.NewGameID(),
+			isValidFile:                    true,
+			imageType:                      values.GameImageTypeJpeg,
+			executeRepositorySaveGameImage: true,
+			executeStorageSaveGameImage:    true,
+			StorageSaveGameImageErr:        errors.New("error"),
+			isErr:                          true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+
+			mockGameImageStorage := mockStorage.NewGameImage(ctrl, buf)
+
+			gameImageService := NewGameImage(
+				mockDB,
+				mockGameRepository,
+				mockGameImageRepository,
+				mockGameImageStorage,
+			)
+
+			var file io.Reader
+			var expectBytes []byte
+			if testCase.isValidFile {
+				img := image.NewRGBA(image.Rect(0, 0, 100, 100))
+				imgBuf := bytes.NewBuffer(nil)
+
+				switch testCase.imageType {
+				case values.GameImageTypeJpeg:
+					err := jpeg.Encode(imgBuf, img, nil)
+					if err != nil {
+						t.Fatalf("failed to encode image: %v\n", err)
+					}
+				case values.GameImageTypePng:
+					err := png.Encode(imgBuf, img)
+					if err != nil {
+						t.Fatalf("failed to encode image: %v\n", err)
+					}
+				case values.GameImageTypeGif:
+					err := gif.Encode(imgBuf, img, nil)
+					if err != nil {
+						t.Fatalf("failed to encode image: %v\n", err)
+					}
+				default:
+					t.Fatalf("invalid image type: %v\n", testCase.imageType)
+				}
+
+				file = imgBuf
+				expectBytes = imgBuf.Bytes()
+			} else {
+				file = strings.NewReader("invalid file")
+			}
+
+			mockGameRepository.
+				EXPECT().
+				GetGame(gomock.Any(), testCase.gameID, repository.LockTypeRecord).
+				Return(nil, testCase.GetGameErr)
+
+			if testCase.executeRepositorySaveGameImage {
+				mockGameImageRepository.
+					EXPECT().
+					SaveGameImage(ctx, testCase.gameID, gomock.Any()).
+					Return(testCase.RepositorySaveGameImageErr)
+			}
+
+			if testCase.executeStorageSaveGameImage {
+				mockGameImageStorage.
+					EXPECT().
+					SaveGameImage(ctx, gomock.Any()).
+					Return(testCase.StorageSaveGameImageErr)
+			}
+
+			err := gameImageService.SaveGameImage(ctx, file, testCase.gameID)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, expectBytes, buf.Bytes())
+		})
+	}
+}

--- a/src/service/v1/game_image_test.go
+++ b/src/service/v1/game_image_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/repository"
 	mockRepository "github.com/traPtitech/trap-collection-server/src/repository/mock"
@@ -182,6 +183,217 @@ func TestSaveGameImage(t *testing.T) {
 			}
 
 			err := gameImageService.SaveGameImage(ctx, file, testCase.gameID)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, expectBytes, buf.Bytes())
+		})
+	}
+}
+
+func TestGetGameImage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mockRepository.NewMockDB(ctrl)
+	mockGameRepository := mockRepository.NewMockGame(ctrl)
+	mockGameImageRepository := mockRepository.NewMockGameImage(ctrl)
+
+	type test struct {
+		description                   string
+		gameID                        values.GameID
+		GetGameErr                    error
+		isValidFile                   bool
+		imageType                     values.GameImageType
+		executeRepositoryGetGameImage bool
+		image                         *domain.GameImage
+		RepositoryGetGameImageErr     error
+		executeStorageGetGameImage    bool
+		StorageGetGameImageErr        error
+		isErr                         bool
+		err                           error
+	}
+
+	testCases := []test{
+		{
+			description:                   "特に問題ないのでエラーなし",
+			gameID:                        values.NewGameID(),
+			isValidFile:                   true,
+			imageType:                     values.GameImageTypeJpeg,
+			executeRepositoryGetGameImage: true,
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeJpeg,
+			),
+			executeStorageGetGameImage: true,
+		},
+		{
+			description: "GetGameがErrRecordNotFoundなのでErrInvalidGameID",
+			gameID:      values.NewGameID(),
+			isValidFile: true,
+			imageType:   values.GameImageTypeJpeg,
+			GetGameErr:  repository.ErrRecordNotFound,
+			isErr:       true,
+			err:         service.ErrInvalidGameID,
+		},
+		{
+			description: "GetGameがエラーなのでエラー",
+			gameID:      values.NewGameID(),
+			isValidFile: true,
+			imageType:   values.GameImageTypeJpeg,
+			GetGameErr:  errors.New("error"),
+			isErr:       true,
+		},
+		{
+			description:                   "画像がpngでもエラーなし",
+			gameID:                        values.NewGameID(),
+			isValidFile:                   true,
+			imageType:                     values.GameImageTypePng,
+			executeRepositoryGetGameImage: true,
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeJpeg,
+			),
+			executeStorageGetGameImage: true,
+		},
+		{
+			description:                   "画像がgifでもエラーなし",
+			gameID:                        values.NewGameID(),
+			isValidFile:                   true,
+			imageType:                     values.GameImageTypeGif,
+			executeRepositoryGetGameImage: true,
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeJpeg,
+			),
+			executeStorageGetGameImage: true,
+		},
+		{
+			// 実際には発生しないが、念のため確認
+			description:                   "画像が不正でもエラーなし",
+			gameID:                        values.NewGameID(),
+			isValidFile:                   false,
+			executeRepositoryGetGameImage: true,
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeJpeg,
+			),
+			executeStorageGetGameImage: true,
+		},
+		{
+			description:                   "repository.GetGameImageがErrRecordNotFoundなのでErrNoGameImage",
+			gameID:                        values.NewGameID(),
+			isValidFile:                   true,
+			imageType:                     values.GameImageTypeJpeg,
+			executeRepositoryGetGameImage: true,
+			RepositoryGetGameImageErr:     repository.ErrRecordNotFound,
+			isErr:                         true,
+			err:                           service.ErrNoGameImage,
+		},
+		{
+			description:                   "repository.GetGameImageがエラーなのでエラー",
+			gameID:                        values.NewGameID(),
+			isValidFile:                   true,
+			imageType:                     values.GameImageTypeJpeg,
+			executeRepositoryGetGameImage: true,
+			RepositoryGetGameImageErr:     errors.New("error"),
+			isErr:                         true,
+		},
+		{
+			description:                   "storage.GetGameImageがエラーなのでエラー",
+			gameID:                        values.NewGameID(),
+			isValidFile:                   true,
+			imageType:                     values.GameImageTypeJpeg,
+			executeRepositoryGetGameImage: true,
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeJpeg,
+			),
+			executeStorageGetGameImage: true,
+			StorageGetGameImageErr:     errors.New("error"),
+			isErr:                      true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			var file *bytes.Buffer
+			if testCase.isValidFile {
+				img := image.NewRGBA(image.Rect(0, 0, 100, 100))
+				imgBuf := bytes.NewBuffer(nil)
+
+				switch testCase.imageType {
+				case values.GameImageTypeJpeg:
+					err := jpeg.Encode(imgBuf, img, nil)
+					if err != nil {
+						t.Fatalf("failed to encode image: %v\n", err)
+					}
+				case values.GameImageTypePng:
+					err := png.Encode(imgBuf, img)
+					if err != nil {
+						t.Fatalf("failed to encode image: %v\n", err)
+					}
+				case values.GameImageTypeGif:
+					err := gif.Encode(imgBuf, img, nil)
+					if err != nil {
+						t.Fatalf("failed to encode image: %v\n", err)
+					}
+				default:
+					t.Fatalf("invalid image type: %v\n", testCase.imageType)
+				}
+
+				file = imgBuf
+			} else {
+				file = bytes.NewBufferString("invalid file")
+			}
+			expectBytes := file.Bytes()
+
+			mockGameImageStorage := mockStorage.NewGameImage(ctrl, file)
+
+			gameImageService := NewGameImage(
+				mockDB,
+				mockGameRepository,
+				mockGameImageRepository,
+				mockGameImageStorage,
+			)
+
+			mockGameRepository.
+				EXPECT().
+				GetGame(ctx, testCase.gameID, repository.LockTypeNone).
+				Return(nil, testCase.GetGameErr)
+
+			if testCase.executeRepositoryGetGameImage {
+				mockGameImageRepository.
+					EXPECT().
+					GetGameImage(ctx, testCase.gameID, repository.LockTypeRecord).
+					Return(testCase.image, testCase.RepositoryGetGameImageErr)
+			}
+
+			if testCase.executeStorageGetGameImage {
+				mockGameImageStorage.
+					EXPECT().
+					GetGameImage(ctx, testCase.image).
+					Return(testCase.StorageGetGameImageErr)
+			}
+
+			buf := bytes.NewBuffer(nil)
+
+			err := gameImageService.GetGameImage(ctx, buf, testCase.gameID)
 
 			if testCase.isErr {
 				if testCase.err == nil {

--- a/src/storage/errors.go
+++ b/src/storage/errors.go
@@ -1,0 +1,7 @@
+package storage
+
+import "errors"
+
+var (
+	ErrNotFound = errors.New("not found")
+)

--- a/src/storage/game_image.go
+++ b/src/storage/game_image.go
@@ -1,0 +1,13 @@
+package storage
+
+import (
+	"context"
+	"io"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+)
+
+type GameImage interface {
+	SaveGameImage(ctx context.Context, reader io.Reader, image *domain.GameImage) error
+	GetGameImage(ctx context.Context, writer io.Writer, image *domain.GameImage) error
+}

--- a/src/storage/mock/game_image.go
+++ b/src/storage/mock/game_image.go
@@ -1,0 +1,88 @@
+package mock
+
+import (
+	"bytes"
+	context "context"
+	io "io"
+	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	domain "github.com/traPtitech/trap-collection-server/src/domain"
+)
+
+// GameImage is a mock of GameImage interface.
+type GameImage struct {
+	ctrl     *gomock.Controller
+	recorder *GameImageMockRecorder
+	buf      *bytes.Buffer
+}
+
+// GameImageMockRecorder is the mock recorder for MockGameImage.
+type GameImageMockRecorder struct {
+	mock *GameImage
+}
+
+// NewGameImage creates a new mock instance.
+func NewGameImage(ctrl *gomock.Controller, buf *bytes.Buffer) *GameImage {
+	mock := &GameImage{ctrl: ctrl}
+	mock.recorder = &GameImageMockRecorder{mock}
+	mock.buf = buf
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *GameImage) EXPECT() *GameImageMockRecorder {
+	return m.recorder
+}
+
+// GetGameImage mocks base method.
+func (m *GameImage) GetGameImage(ctx context.Context, writer io.Writer, image *domain.GameImage) error {
+	ret0 := m.getGameImage(ctx, image)
+
+	_, err := io.Copy(writer, m.buf)
+	if err != nil {
+		m.ctrl.T.Fatalf("unexpected error copying from buffer: %v", err)
+	}
+
+	return ret0
+}
+
+// GetGameImage mocks base method.
+func (m *GameImage) getGameImage(ctx context.Context, image *domain.GameImage) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGameImage", ctx, image)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetGameImage indicates an expected call of GetGameImage.
+func (mr *GameImageMockRecorder) GetGameImage(ctx, image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGameImage", reflect.TypeOf((*GameImage)(nil).GetGameImage), ctx, image)
+}
+
+// SaveGameImage mocks base method.
+func (m *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, image *domain.GameImage) error {
+	ret0 := m.saveGameImage(ctx, image)
+
+	_, err := io.Copy(m.buf, reader)
+	if err != nil {
+		m.ctrl.T.Fatalf("unexpected error copying to buffer: %v", err)
+	}
+
+	return ret0
+}
+
+func (m *GameImage) saveGameImage(ctx context.Context, image *domain.GameImage) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveGameImage", ctx, image)
+	ret0, _ := ret[0].(error)
+
+	return ret0
+}
+
+// SaveGameImage indicates an expected call of SaveGameImage.
+func (mr *GameImageMockRecorder) SaveGameImage(ctx, image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveGameImage", reflect.TypeOf((*GameImage)(nil).saveGameImage), ctx, image)
+}


### PR DESCRIPTION
実装した。
storageはファイルの保存場所。
本番環境ではConoHaのオブジェクトストレージにローカルファイルでのキャッシュを挟んだものを使用する。
手元での動作確認用にローカルファイルのみのものも実装する予定。
io.Reader・Writer周りのモックが自動生成のものだとうまくいかないので、自動生成のものを修正している。