### PR TITLE
GameImageサービスのバグ修正

### DIFF
--- a/src/service/v1/game_image.go
+++ b/src/service/v1/game_image.go
@@ -66,6 +66,11 @@ func (gi *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, gameID
 			return service.ErrInvalidFormat
 		}
 
+		_, err = io.ReadAll(r)
+		if err != nil {
+			return fmt.Errorf("failed to read image: %w", err)
+		}
+
 		image := domain.NewGameImage(
 			values.NewGameImageID(),
 			imageType,

--- a/src/service/v1/game_image_test.go
+++ b/src/service/v1/game_image_test.go
@@ -134,7 +134,7 @@ func TestSaveGameImage(t *testing.T) {
 			var file io.Reader
 			var expectBytes []byte
 			if testCase.isValidFile {
-				img := image.NewRGBA(image.Rect(0, 0, 100, 100))
+				img := image.NewRGBA(image.Rect(0, 0, 3000, 3000))
 				imgBuf := bytes.NewBuffer(nil)
 
 				switch testCase.imageType {


### PR DESCRIPTION
TeeReaderを使っていたが、`ReadAll`しておらずある程度大きい画像だとうまく動いていなかった。
テストでは100px x 100pxの画像を生成して使っていたため引っ掛かっていなかった。
今回のような場合でも引っかかるようにテストで使う画像を3000px x 3000pxのかなり大きめの画像に変更している(修正前の状態でテストに落ちた画像の大きさがこれだった)。
