### PR TITLE
GameImageのオブジェクトストレージとの接続部分実装

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,12 +17,16 @@ require (
 	github.com/labstack/echo-contrib v0.9.0
 	github.com/labstack/echo/v4 v4.1.16
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
+	github.com/ncw/swift/v2 v2.0.1
 	github.com/stretchr/testify v1.4.0
 	github.com/t-tiger/gorm-bulk-insert v1.3.0
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
 	golang.org/x/mod v0.5.1
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	gopkg.in/djherbis/atime.v1 v1.0.0 // indirect
+	gopkg.in/djherbis/fscache.v0 v0.10.1
+	gopkg.in/djherbis/stream.v1 v1.3.1 // indirect
 	gorm.io/driver/mysql v1.1.2
 	gorm.io/gorm v1.21.15
 )

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/ncw/swift/v2 v2.0.1 h1:q1IN8hNViXEv8Zvg3Xdis4a3c4IlIGezkYz09zQL5J0=
+github.com/ncw/swift/v2 v2.0.1/go.mod h1:z0A9RVdYPjNjXVo2pDOPxZ4eu3oarO1P91fTItcb+Kg=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -281,6 +283,12 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/djherbis/atime.v1 v1.0.0 h1:eMRqB/JrLKocla2PBPKgQYg/p5UG4L6AUAs92aP7F60=
+gopkg.in/djherbis/atime.v1 v1.0.0/go.mod h1:hQIUStKmJfvf7xdh/wtK84qe+DsTV5LnA9lzxxtPpJ8=
+gopkg.in/djherbis/fscache.v0 v0.10.1 h1:yR4BF9YhXv+2B+of3wn0r9KYXtfbvLLkHvCkYAwrdvc=
+gopkg.in/djherbis/fscache.v0 v0.10.1/go.mod h1:izqJMuO+STCEMBEGFiwW5zPlamuiUOxMRpNzHT5cQHc=
+gopkg.in/djherbis/stream.v1 v1.3.1 h1:uGfmsOY1qqMjQQphhRBSGLyA9qumJ56exkRu9ASTjCw=
+gopkg.in/djherbis/stream.v1 v1.3.1/go.mod h1:aEV8CBVRmSpLamVJfM903Npic1IKmb2qS30VAZ+sssg=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -13,5 +13,10 @@ type (
 	SessionSecret  string
 	SessionKey     string
 	Administrators []values.TraPMemberName
+	SwiftAuthURL   *url.URL
+	SwiftUserName  string
+	SwiftPassword  string
+	SwiftTenantID  string
+	SwiftContainer string
 	FilePath       string
 )

--- a/src/storage/swift/client.go
+++ b/src/storage/swift/client.go
@@ -1,0 +1,77 @@
+package swift
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/ncw/swift/v2"
+	"github.com/traPtitech/trap-collection-server/pkg/common"
+	"gopkg.in/djherbis/fscache.v0"
+)
+
+const (
+	cacheDuration = 7 * 24 * time.Hour
+)
+
+type Client struct {
+	connection    *swift.Connection
+	containerName string
+	cache         fscache.Cache
+}
+
+func NewClient(
+	authURL common.SwiftAuthURL,
+	userName common.SwiftUserName,
+	password common.SwiftPassword,
+	tennantID common.SwiftTenantID,
+	containerName common.SwiftContainer,
+	cacheDirectory common.FilePath,
+) (*Client, error) {
+	ctx := context.Background()
+
+	connection, err := setupSwift(
+		ctx,
+		(*url.URL)(authURL),
+		string(userName),
+		string(password),
+		string(tennantID),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup swift: %w", err)
+	}
+
+	cache, err := fscache.New(string(cacheDirectory), 0755, cacheDuration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup cache: %w", err)
+	}
+
+	return &Client{
+		connection:    connection,
+		containerName: string(containerName),
+		cache:         cache,
+	}, nil
+}
+
+func setupSwift(
+	ctx context.Context,
+	authURL *url.URL,
+	userName string,
+	password string,
+	tennantID string,
+) (*swift.Connection, error) {
+	c := &swift.Connection{
+		UserName: userName,
+		ApiKey:   password,
+		AuthUrl:  authURL.String(),
+		Tenant:   tennantID,
+	}
+
+	err := c.Authenticate(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to authenticate: %w", err)
+	}
+
+	return c, nil
+}

--- a/src/storage/swift/client_test.go
+++ b/src/storage/swift/client_test.go
@@ -1,13 +1,19 @@
 package swift
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/ncw/swift/v2"
 	"github.com/ncw/swift/v2/swifttest"
+	"github.com/stretchr/testify/assert"
 	"github.com/traPtitech/trap-collection-server/pkg/common"
 )
 
@@ -52,4 +58,154 @@ func newTestClient(ctx context.Context, containerName common.SwiftContainer, cac
 	}
 
 	return client, err
+}
+
+func TestSaveFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	client, err := newTestClient(
+		ctx,
+		common.SwiftContainer("save_file"),
+		common.FilePath("save_file"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll("save_file")
+		if err != nil {
+			t.Fatalf("failed to remove directory: %v", err)
+		}
+	}()
+
+	type test struct {
+		description        string
+		name               string
+		contentType        string
+		hash               string
+		content            *bytes.Buffer
+		isAlreadyFileExist bool
+		isErr              bool
+		err                error
+	}
+
+	testCases := []test{
+		{
+			description: "特に問題ないので保存できる",
+			name:        "a",
+			contentType: "text/plain",
+			content:     bytes.NewBufferString("a"),
+		},
+		{
+			description:        "ファイルが既に存在するのでErrAlreadyExists",
+			name:               "b",
+			contentType:        "text/plain",
+			content:            bytes.NewBufferString("b"),
+			isAlreadyFileExist: true,
+			isErr:              true,
+			err:                ErrAlreadyExists,
+		},
+		{
+			description: "hashが設定されていても保存できる",
+			name:        "c",
+			contentType: "text/plain",
+			content:     bytes.NewBufferString("c"),
+			hash:        "4a8a08f09d37b73795649038408b5f33",
+		},
+		{
+			description: "hashが誤っているのでエラー",
+			name:        "d",
+			contentType: "text/plain",
+			content:     bytes.NewBufferString("d"),
+			// 正しい値: 8277e0910d750195b448797616e091ad
+			hash:  "invalid",
+			isErr: true,
+		},
+		{
+			description: "サイズが大きくても保存できる",
+			name:        "e",
+			contentType: "text/plain",
+			content:     bytes.NewBufferString(strings.Repeat("e", 1024*1024*10)),
+		},
+		{
+			description: "ファイル名に/が含まれていても保存できる",
+			name:        "f/g",
+			contentType: "text/plain",
+			content:     bytes.NewBufferString("f"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			defer func() {
+				// 確実にキャッシュが残るように、キャッシュを消す
+				err := client.cache.Clean()
+				if err != nil {
+					t.Fatalf("failed to clean cache: %v", err)
+				}
+			}()
+
+			expectBytes := testCase.content.Bytes()
+
+			if testCase.isAlreadyFileExist {
+				err := client.connection.ObjectPutBytes(ctx, client.containerName, testCase.name, []byte{0}, testCase.contentType)
+				if err != nil {
+					t.Fatalf("failed to put object: %v", err)
+				}
+			}
+
+			err := client.saveFile(
+				ctx,
+				testCase.name,
+				testCase.contentType,
+				testCase.hash,
+				testCase.content,
+			)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			_, _, err = client.connection.Object(ctx, client.containerName, testCase.name)
+			if errors.Is(err, swift.ObjectNotFound) {
+				t.Fatalf("object not found: %v", err)
+			}
+			if err != nil {
+				t.Fatalf("failed to get object: %v", err)
+			}
+
+			actualBytes, err := client.connection.ObjectGetBytes(ctx, client.containerName, testCase.name)
+			if err != nil {
+				t.Fatalf("failed to get object: %v", err)
+			}
+
+			assert.Equal(t, expectBytes, actualBytes)
+
+			assert.True(t, client.cache.Exists(testCase.name))
+
+			r, _, err := client.cache.Get(testCase.name)
+			if err != nil {
+				t.Fatalf("failed to get cache: %v", err)
+			}
+			defer r.Close()
+
+			actualBytes, err = io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("failed to read cache: %v", err)
+			}
+
+			assert.Equal(t, expectBytes, actualBytes)
+		})
+	}
 }

--- a/src/storage/swift/client_test.go
+++ b/src/storage/swift/client_test.go
@@ -1,0 +1,55 @@
+package swift
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/ncw/swift/v2/swifttest"
+	"github.com/traPtitech/trap-collection-server/pkg/common"
+)
+
+var testServer *swifttest.SwiftServer
+
+func TestMain(m *testing.M) {
+	var err error
+	testServer, err = swifttest.NewSwiftServer("")
+	if err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+
+	testServer.Close()
+
+	os.Exit(code)
+}
+
+func newTestClient(ctx context.Context, containerName common.SwiftContainer, cacheDirectory common.FilePath) (*Client, error) {
+	authURL, err := url.Parse(testServer.AuthURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse auth url: %w", err)
+	}
+
+	client, err := NewClient(
+		common.SwiftAuthURL(authURL),
+		common.SwiftUserName(swifttest.TEST_ACCOUNT),
+		common.SwiftPassword(swifttest.TEST_ACCOUNT),
+		// テスト用サーバーはv1での認証なので、tenantIDは必要ない
+		common.SwiftTenantID(""),
+		common.SwiftContainer(containerName),
+		cacheDirectory,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	err = client.connection.ContainerCreate(ctx, string(containerName), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create container: %w", err)
+	}
+
+	return client, err
+}

--- a/src/storage/swift/game_image.go
+++ b/src/storage/swift/game_image.go
@@ -54,6 +54,24 @@ func (gi *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, image 
 	return nil
 }
 
+func (gi *GameImage) GetGameImage(ctx context.Context, writer io.Writer, image *domain.GameImage) error {
+	imageKey := gi.imageKey(image)
+
+	err := gi.client.loadFile(
+		ctx,
+		imageKey,
+		writer,
+	)
+	if errors.Is(err, ErrNotFound) {
+		return storage.ErrNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get image: %w", err)
+	}
+
+	return nil
+}
+
 // imageKey 変更時にはオブジェクトストレージのキーを変更する必要があるので要注意
 func (gi *GameImage) imageKey(image *domain.GameImage) string {
 	return fmt.Sprintf("images/%s", uuid.UUID(image.GetID()).String())

--- a/src/storage/swift/game_image.go
+++ b/src/storage/swift/game_image.go
@@ -1,10 +1,15 @@
 package swift
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/google/uuid"
 	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/storage"
 )
 
 type GameImage struct {
@@ -15,6 +20,38 @@ func NewGameImage(client *Client) *GameImage {
 	return &GameImage{
 		client: client,
 	}
+}
+
+func (gi *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, image *domain.GameImage) error {
+	imageKey := gi.imageKey(image)
+
+	var contentType string
+	switch image.GetType() {
+	case values.GameImageTypeJpeg:
+		contentType = "image/jpeg"
+	case values.GameImageTypePng:
+		contentType = "image/png"
+	case values.GameImageTypeGif:
+		contentType = "image/gif"
+	default:
+		return fmt.Errorf("unsupported image type: %d", image.GetType())
+	}
+
+	err := gi.client.saveFile(
+		ctx,
+		imageKey,
+		contentType,
+		"",
+		reader,
+	)
+	if errors.Is(err, ErrAlreadyExists) {
+		return storage.ErrAlreadyExists
+	}
+	if err != nil {
+		return fmt.Errorf("failed to save image: %w", err)
+	}
+
+	return nil
 }
 
 // imageKey 変更時にはオブジェクトストレージのキーを変更する必要があるので要注意

--- a/src/storage/swift/game_image.go
+++ b/src/storage/swift/game_image.go
@@ -1,0 +1,11 @@
+package swift
+
+type GameImage struct {
+	client *Client
+}
+
+func NewGameImage(client *Client) *GameImage {
+	return &GameImage{
+		client: client,
+	}
+}

--- a/src/storage/swift/game_image.go
+++ b/src/storage/swift/game_image.go
@@ -1,5 +1,12 @@
 package swift
 
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+)
+
 type GameImage struct {
 	client *Client
 }
@@ -8,4 +15,9 @@ func NewGameImage(client *Client) *GameImage {
 	return &GameImage{
 		client: client,
 	}
+}
+
+// imageKey 変更時にはオブジェクトストレージのキーを変更する必要があるので要注意
+func (gi *GameImage) imageKey(image *domain.GameImage) string {
+	return fmt.Sprintf("images/%s", uuid.UUID(image.GetID()).String())
 }

--- a/src/storage/swift/game_image_test.go
+++ b/src/storage/swift/game_image_test.go
@@ -1,15 +1,164 @@
 package swift
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
+	"image"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
 	"math/rand"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/trap-collection-server/pkg/common"
 	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/storage"
 )
+
+func TestSaveGameImage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	client, err := newTestClient(
+		ctx,
+		common.SwiftContainer("save_game_image"),
+		common.FilePath("save_game_image"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll("save_game_image")
+		if err != nil {
+			t.Fatalf("failed to remove directory: %v", err)
+		}
+	}()
+
+	type test struct {
+		description string
+		image       *domain.GameImage
+		isFileExist bool
+		isErr       bool
+		err         error
+	}
+
+	testCases := []test{
+		{
+			description: "特に問題ないのでエラーなし",
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeJpeg,
+			),
+		},
+		{
+			description: "pngでもエラーなし",
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypePng,
+			),
+		},
+		{
+			description: "gifでもエラーなし",
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeGif,
+			),
+		},
+		{
+			description: "想定外のファイルタイプなのでエラー",
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				100,
+			),
+			isErr: true,
+		},
+		{
+			description: "ファイルが存在するのでErrAlreadyExists",
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeJpeg,
+			),
+			isFileExist: true,
+			isErr:       true,
+			err:         storage.ErrAlreadyExists,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			gameImageStorage := NewGameImage(client)
+
+			if testCase.isFileExist {
+				err := client.saveFile(
+					ctx,
+					fmt.Sprintf("images/%s", uuid.UUID(testCase.image.GetID()).String()),
+					"text/plain",
+					"",
+					strings.NewReader(""),
+				)
+				if err != nil {
+					t.Fatalf("failed to create file: %v", err)
+				}
+			}
+
+			var expectBytes []byte
+			img := image.NewRGBA(image.Rect(0, 0, 3000, 3000))
+			imgBuf := bytes.NewBuffer(nil)
+
+			switch testCase.image.GetType() {
+			case values.GameImageTypeJpeg:
+				err := jpeg.Encode(imgBuf, img, nil)
+				if err != nil {
+					t.Fatalf("failed to encode image: %v\n", err)
+				}
+			case values.GameImageTypePng:
+				err := png.Encode(imgBuf, img)
+				if err != nil {
+					t.Fatalf("failed to encode image: %v\n", err)
+				}
+			case values.GameImageTypeGif:
+				err := gif.Encode(imgBuf, img, nil)
+				if err != nil {
+					t.Fatalf("failed to encode image: %v\n", err)
+				}
+			default:
+				imgBuf = bytes.NewBufferString("hoge")
+			}
+			expectBytes = imgBuf.Bytes()
+
+			err := gameImageStorage.SaveGameImage(ctx, imgBuf, testCase.image)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			buf := bytes.NewBuffer(nil)
+			err = client.loadFile(ctx, fmt.Sprintf("images/%s", uuid.UUID(testCase.image.GetID()).String()), buf)
+			if err != nil {
+				t.Fatalf("failed to load file: %v", err)
+			}
+
+			assert.Equal(t, expectBytes, buf.Bytes())
+		})
+	}
+}
 
 func TestImageKey(t *testing.T) {
 	t.Parallel()

--- a/src/storage/swift/game_image_test.go
+++ b/src/storage/swift/game_image_test.go
@@ -160,6 +160,133 @@ func TestSaveGameImage(t *testing.T) {
 	}
 }
 
+func TestGetGameImage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	client, err := newTestClient(
+		ctx,
+		common.SwiftContainer("get_game_image"),
+		common.FilePath("get_game_image"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll("get_game_image")
+		if err != nil {
+			t.Fatalf("failed to remove directory: %v", err)
+		}
+	}()
+
+	gameImageStorage := NewGameImage(client)
+
+	type test struct {
+		description string
+		image       *domain.GameImage
+		isFileExist bool
+		isErr       bool
+		err         error
+	}
+
+	testCases := []test{
+		{
+			description: "特に問題ないのでエラーなし",
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeJpeg,
+			),
+			isFileExist: true,
+		},
+		{
+			description: "pngでもエラーなし",
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypePng,
+			),
+			isFileExist: true,
+		},
+		{
+			description: "gifでもエラーなし",
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeGif,
+			),
+			isFileExist: true,
+		},
+		{
+			description: "ファイルが存在しないのでErrNotFound",
+			image: domain.NewGameImage(
+				values.NewGameImageID(),
+				values.GameImageTypeJpeg,
+			),
+			isErr: true,
+			err:   storage.ErrNotFound,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			var expectBytes []byte
+			img := image.NewRGBA(image.Rect(0, 0, 3000, 3000))
+			imgBuf := bytes.NewBuffer(nil)
+
+			switch testCase.image.GetType() {
+			case values.GameImageTypeJpeg:
+				err := jpeg.Encode(imgBuf, img, nil)
+				if err != nil {
+					t.Fatalf("failed to encode image: %v\n", err)
+				}
+			case values.GameImageTypePng:
+				err := png.Encode(imgBuf, img)
+				if err != nil {
+					t.Fatalf("failed to encode image: %v\n", err)
+				}
+			case values.GameImageTypeGif:
+				err := gif.Encode(imgBuf, img, nil)
+				if err != nil {
+					t.Fatalf("failed to encode image: %v\n", err)
+				}
+			default:
+				imgBuf = bytes.NewBufferString("hoge")
+			}
+			expectBytes = imgBuf.Bytes()
+
+			if testCase.isFileExist {
+				err := client.saveFile(
+					ctx,
+					fmt.Sprintf("images/%s", uuid.UUID(testCase.image.GetID()).String()),
+					"",
+					"",
+					imgBuf,
+				)
+				if err != nil {
+					t.Fatalf("failed to create file: %v", err)
+				}
+			}
+
+			buf := bytes.NewBuffer(nil)
+			err := gameImageStorage.GetGameImage(ctx, buf, testCase.image)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, expectBytes, buf.Bytes())
+		})
+	}
+}
+
 func TestImageKey(t *testing.T) {
 	t.Parallel()
 

--- a/src/storage/swift/game_image_test.go
+++ b/src/storage/swift/game_image_test.go
@@ -1,0 +1,34 @@
+package swift
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
+
+func TestImageKey(t *testing.T) {
+	t.Parallel()
+
+	// clientは使わないのでnilでOK
+	gameImageStorage := NewGameImage(nil)
+
+	loopNum := 100
+
+	for i := 0; i < loopNum; i++ {
+		imageID := values.NewGameImageID()
+
+		image := domain.NewGameImage(
+			imageID,
+			values.GameImageType(rand.Intn(3)),
+		)
+
+		key := gameImageStorage.imageKey(image)
+
+		assert.Equal(t, fmt.Sprintf("images/%s", uuid.UUID(image.GetID()).String()), key)
+	}
+}


### PR DESCRIPTION
オブジェクトストレージへの保存部分を実装した。
オブジェクトストレージとの通信に使うパッケージは、テストのためのmockサーバー機能などがより充実していたためgophercloudのものから https://github.com/ncw/swift に変更している。
https://github.com/djherbis/fscache を用いてのアプリケーション側でのキャッシュも実装している。