### PR TITLE
二重のエラーハンドリング修正

### DIFF
--- a/src/service/v1/launcher_auth.go
+++ b/src/service/v1/launcher_auth.go
@@ -61,9 +61,6 @@ func (la *LauncherAuth) CreateLauncherUser(ctx context.Context, launcherVersionI
 	if err != nil {
 		return nil, fmt.Errorf("failed to create launcher users: %w", err)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("failed in transaction: %w", err)
-	}
 
 	return launcherUsers, nil
 }


### PR DESCRIPTION
トランザクションを消したときにエラーハンドリングを消すのを忘れており、2重でエラーハンドリングをしている箇所があったので修正した。