### PR TITLE
GameFileサービス実装とGameVersionリポジトリ修正取り込み

### DIFF
--- a/src/domain/game_file.go
+++ b/src/domain/game_file.go
@@ -6,17 +6,20 @@ import (
 
 type GameFile struct {
 	id         values.GameFileID
+	fileType   values.GameFileType
 	entryPoint values.GameFileEntryPoint
 	hash       values.GameFileHash
 }
 
 func NewGameFile(
 	id values.GameFileID,
+	fileType values.GameFileType,
 	entryPoint values.GameFileEntryPoint,
 	hash values.GameFileHash,
 ) *GameFile {
 	return &GameFile{
 		id:         id,
+		fileType:   fileType,
 		entryPoint: entryPoint,
 		hash:       hash,
 	}
@@ -24,6 +27,10 @@ func NewGameFile(
 
 func (gf *GameFile) GetID() values.GameFileID {
 	return gf.id
+}
+
+func (gf *GameFile) GetFileType() values.GameFileType {
+	return gf.fileType
 }
 
 func (gf *GameFile) GetEntryPoint() values.GameFileEntryPoint {

--- a/src/domain/values/launcher_environment.go
+++ b/src/domain/values/launcher_environment.go
@@ -1,0 +1,38 @@
+package values
+
+type LauncherEnvironment struct {
+	os LauncherEnvironmentOS
+}
+
+func NewLauncherEnvironment(os LauncherEnvironmentOS) *LauncherEnvironment {
+	return &LauncherEnvironment{
+		os: os,
+	}
+}
+
+func (le *LauncherEnvironment) AcceptGameFileTypes() []GameFileType {
+	switch le.os {
+	case LauncherEnvironmentOSWindows:
+		return []GameFileType{
+			GameFileTypeJar,
+			GameFileTypeWindows,
+		}
+	case LauncherEnvironmentOSMac:
+		return []GameFileType{
+			GameFileTypeJar,
+			GameFileTypeMac,
+		}
+	}
+
+	return nil
+}
+
+type (
+	LauncherEnvironmentOS int
+)
+
+const (
+	LauncherEnvironmentOSWindows LauncherEnvironmentOS = iota
+	// LauncherEnvironmentOSMac 今のところ稼働させる予定なし
+	LauncherEnvironmentOSMac
+)

--- a/src/domain/values/launcher_environment_test.go
+++ b/src/domain/values/launcher_environment_test.go
@@ -1,0 +1,49 @@
+package values
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLauncherEnvironmentAcceptGameFileTypes(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		description     string
+		environment     *LauncherEnvironment
+		acceptFileTypes []GameFileType
+	}
+
+	testCases := []test{
+		{
+			description: "windowsの場合、jarとwindowsを許可する",
+			environment: &LauncherEnvironment{
+				os: LauncherEnvironmentOSWindows,
+			},
+			acceptFileTypes: []GameFileType{
+				GameFileTypeJar,
+				GameFileTypeWindows,
+			},
+		},
+		{
+			description: "macの場合、jarとmacを許可する",
+			environment: &LauncherEnvironment{
+				os: LauncherEnvironmentOSMac,
+			},
+			acceptFileTypes: []GameFileType{
+				GameFileTypeJar,
+				GameFileTypeMac,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			acceptFileTypes := testCase.environment.AcceptGameFileTypes()
+
+			assert.Len(t, acceptFileTypes, len(testCase.acceptFileTypes))
+			assert.Subset(t, acceptFileTypes, testCase.acceptFileTypes)
+		})
+	}
+}

--- a/src/repository/game_file.go
+++ b/src/repository/game_file.go
@@ -1,0 +1,15 @@
+package repository
+
+//go:generate mockgen -source=$GOFILE -destination=mock/${GOFILE} -package=mock
+
+import (
+	"context"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
+
+type GameFile interface {
+	SaveGameFile(ctx context.Context, gameVersionID values.GameVersionID, gameFile *domain.GameFile) error
+	GetGameFiles(ctx context.Context, gameVersionID values.GameVersionID, fileTypes []values.GameFileType) ([]*domain.GameFile, error)
+}

--- a/src/repository/game_version.go
+++ b/src/repository/game_version.go
@@ -13,4 +13,5 @@ type GameVersion interface {
 	CreateGameVersion(ctx context.Context, gameID values.GameID, version *domain.GameVersion) error
 	// GetGameVersions CreatedAtで降順にソートしたGameVersionのリストを取得
 	GetGameVersions(ctx context.Context, gameID values.GameID) ([]*domain.GameVersion, error)
+	GetLatestGameVersion(ctx context.Context, gameID values.GameID, lockType LockType) (*domain.GameVersion, error)
 }

--- a/src/repository/gorm2/game_version_test.go
+++ b/src/repository/gorm2/game_version_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/repository"
 	"gorm.io/gorm"
 )
 
@@ -603,6 +604,274 @@ func TestGetGameVersions(t *testing.T) {
 				assert.Equal(t, expectVersion.GetDescription(), actualVersion.GetDescription())
 				assert.WithinDuration(t, expectVersion.GetCreatedAt(), actualVersion.GetCreatedAt(), 2*time.Second)
 			}
+		})
+	}
+}
+
+func TestGetLatestGameVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	db, err := testDB.getDB(ctx)
+	if err != nil {
+		t.Fatalf("failed to get db: %v", err)
+	}
+
+	gameVersionRepository := NewGameVersion(testDB)
+
+	type test struct {
+		description string
+		gameID      values.GameID
+		lockType    repository.LockType
+		games       []GameTable
+		expect      *domain.GameVersion
+		isErr       bool
+		err         error
+	}
+
+	gameID1 := values.NewGameID()
+	gameID2 := values.NewGameID()
+	gameID3 := values.NewGameID()
+	gameID4 := values.NewGameID()
+	gameID5 := values.NewGameID()
+	gameID6 := values.NewGameID()
+	gameID7 := values.NewGameID()
+	gameID8 := values.NewGameID()
+
+	gameVersionID1 := values.NewGameVersionID()
+	gameVersionID2 := values.NewGameVersionID()
+	gameVersionID3 := values.NewGameVersionID()
+	gameVersionID4 := values.NewGameVersionID()
+	gameVersionID5 := values.NewGameVersionID()
+	gameVersionID6 := values.NewGameVersionID()
+	gameVersionID7 := values.NewGameVersionID()
+
+	testCases := []test{
+		{
+			description: "特に問題ないのでエラーなし",
+			gameID:      gameID1,
+			lockType:    repository.LockTypeNone,
+			games: []GameTable{
+				{
+					ID:          uuid.UUID(gameID1),
+					Name:        "test",
+					Description: "test",
+					CreatedAt:   time.Now(),
+					GameVersions: []GameVersionTable{
+						{
+							ID:          uuid.UUID(gameVersionID1),
+							Name:        "v1.0.0",
+							Description: "リリース",
+							CreatedAt:   time.Now(),
+						},
+					},
+				},
+			},
+			expect: domain.NewGameVersion(
+				gameVersionID1,
+				values.NewGameVersionName("v1.0.0"),
+				values.NewGameVersionDescription("リリース"),
+				time.Now(),
+			),
+		},
+		{
+			// 実際には発生しないが、念のため確認
+			description: "ゲームが存在しないのでErrRecordNotFound",
+			gameID:      gameID2,
+			lockType:    repository.LockTypeNone,
+			games:       []GameTable{},
+			isErr:       true,
+			err:         repository.ErrRecordNotFound,
+		},
+		{
+			// 実際には発生しないが、念のため確認
+			description: "ゲームが削除されていてもエラーなし",
+			gameID:      gameID3,
+			lockType:    repository.LockTypeNone,
+			games: []GameTable{
+				{
+					ID:          uuid.UUID(gameID3),
+					Name:        "test",
+					Description: "test",
+					CreatedAt:   time.Now(),
+					DeletedAt: gorm.DeletedAt{
+						Time:  time.Now(),
+						Valid: true,
+					},
+					GameVersions: []GameVersionTable{
+						{
+							ID:          uuid.UUID(gameVersionID2),
+							Name:        "v1.0.0",
+							Description: "リリース",
+							CreatedAt:   time.Now(),
+						},
+					},
+				},
+			},
+			expect: domain.NewGameVersion(
+				gameVersionID2,
+				values.NewGameVersionName("v1.0.0"),
+				values.NewGameVersionDescription("リリース"),
+				time.Now(),
+			),
+		},
+		{
+			description: "バージョンが複数あってもエラーなし",
+			gameID:      gameID4,
+			lockType:    repository.LockTypeNone,
+			games: []GameTable{
+				{
+					ID:          uuid.UUID(gameID4),
+					Name:        "test",
+					Description: "test",
+					CreatedAt:   time.Now(),
+					GameVersions: []GameVersionTable{
+						{
+							ID:          uuid.UUID(gameVersionID3),
+							Name:        "v1.1.0",
+							Description: "アップデート",
+							CreatedAt:   time.Now(),
+						},
+						{
+							ID:          uuid.UUID(gameVersionID4),
+							Name:        "v1.0.0",
+							Description: "リリース",
+							CreatedAt:   time.Now().Add(-time.Hour),
+						},
+					},
+				},
+			},
+			expect: domain.NewGameVersion(
+				gameVersionID3,
+				values.NewGameVersionName("v1.1.0"),
+				values.NewGameVersionDescription("アップデート"),
+				time.Now(),
+			),
+		},
+		{
+			description: "バージョンが存在しないのでErrRecordNotFound",
+			gameID:      gameID5,
+			lockType:    repository.LockTypeNone,
+			games: []GameTable{
+				{
+					ID:          uuid.UUID(gameID5),
+					Name:        "test",
+					Description: "test",
+					CreatedAt:   time.Now(),
+				},
+			},
+			isErr: true,
+			err:   repository.ErrRecordNotFound,
+		},
+		{
+			description: "別のゲームのバージョンが混ざることはない",
+			gameID:      gameID6,
+			lockType:    repository.LockTypeNone,
+			games: []GameTable{
+				{
+					ID:          uuid.UUID(gameID6),
+					Name:        "test",
+					Description: "test",
+					CreatedAt:   time.Now(),
+					GameVersions: []GameVersionTable{
+						{
+							ID:          uuid.UUID(gameVersionID5),
+							Name:        "v1.0.0",
+							Description: "リリース",
+							CreatedAt:   time.Now(),
+						},
+					},
+				},
+				{
+					ID:          uuid.UUID(gameID7),
+					Name:        "test",
+					Description: "test",
+					CreatedAt:   time.Now(),
+					GameVersions: []GameVersionTable{
+						{
+							ID:          uuid.UUID(gameVersionID6),
+							Name:        "v1.0.0",
+							Description: "リリース",
+							CreatedAt:   time.Now(),
+						},
+					},
+				},
+			},
+			expect: domain.NewGameVersion(
+				gameVersionID5,
+				values.NewGameVersionName("v1.0.0"),
+				values.NewGameVersionDescription("リリース"),
+				time.Now(),
+			),
+		},
+		{
+			description: "lockTypeがRecordでもエラーなし",
+			gameID:      gameID8,
+			lockType:    repository.LockTypeRecord,
+			games: []GameTable{
+				{
+					ID:          uuid.UUID(gameID8),
+					Name:        "test",
+					Description: "test",
+					CreatedAt:   time.Now(),
+					GameVersions: []GameVersionTable{
+						{
+							ID:          uuid.UUID(gameVersionID7),
+							Name:        "v1.0.0",
+							Description: "リリース",
+							CreatedAt:   time.Now(),
+						},
+					},
+				},
+			},
+			expect: domain.NewGameVersion(
+				gameVersionID7,
+				values.NewGameVersionName("v1.0.0"),
+				values.NewGameVersionDescription("リリース"),
+				time.Now(),
+			),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			if len(testCase.games) != 0 {
+				err := db.Create(&testCase.games).Error
+				if err != nil {
+					t.Fatalf("failed to create games: %v", err)
+				}
+
+				for _, game := range testCase.games {
+					if game.DeletedAt.Valid {
+						err := db.Delete(&game).Error
+						if err != nil {
+							t.Fatalf("failed to delete game: %v", err)
+						}
+					}
+				}
+			}
+
+			gameVersion, err := gameVersionRepository.GetLatestGameVersion(ctx, testCase.gameID, testCase.lockType)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Log(gameVersion)
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil || testCase.isErr {
+				return
+			}
+
+			assert.Equal(t, testCase.expect.GetID(), gameVersion.GetID())
+			assert.Equal(t, testCase.expect.GetName(), gameVersion.GetName())
+			assert.Equal(t, testCase.expect.GetDescription(), gameVersion.GetDescription())
+			assert.WithinDuration(t, testCase.expect.GetCreatedAt(), gameVersion.GetCreatedAt(), 2*time.Second)
 		})
 	}
 }

--- a/src/service/errors.go
+++ b/src/service/errors.go
@@ -19,4 +19,6 @@ var (
 	ErrInvalidFormat                     = errors.New("invalid format")
 	ErrNoGameImage                       = errors.New("no game image")
 	ErrNoGameVideo                       = errors.New("no game video")
+	ErrNoGameVersion                     = errors.New("no game version")
+	ErrNoGameFile                        = errors.New("no game file")
 )

--- a/src/service/game_file.go
+++ b/src/service/game_file.go
@@ -1,0 +1,16 @@
+package service
+
+//go:generate mockgen -source=$GOFILE -destination=mock/${GOFILE} -package=mock
+
+import (
+	"context"
+	"io"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
+
+type GameFile interface {
+	SaveGameFile(ctx context.Context, reader io.Reader, gameID values.GameID, fileType values.GameFileType, entryPoint values.GameFileEntryPoint) (*domain.GameFile, error)
+	GetGameFile(ctx context.Context, writer io.Writer, gameID values.GameID, environment *values.LauncherEnvironment) (*domain.GameFile, error)
+}

--- a/src/service/v1/game_file.go
+++ b/src/service/v1/game_file.go
@@ -1,0 +1,138 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/repository"
+	"github.com/traPtitech/trap-collection-server/src/service"
+	"github.com/traPtitech/trap-collection-server/src/storage"
+)
+
+type GameFile struct {
+	db                    repository.DB
+	gameRepository        repository.Game
+	gameVersionRepository repository.GameVersion
+	gameFileRepository    repository.GameFile
+	gameFileStorage       storage.GameFile
+}
+
+func NewGameFile(
+	db repository.DB,
+	gameRepository repository.Game,
+	gameVersionRepository repository.GameVersion,
+	gameFileRepository repository.GameFile,
+	gameFileStorage storage.GameFile,
+) *GameFile {
+	return &GameFile{
+		db:                    db,
+		gameRepository:        gameRepository,
+		gameVersionRepository: gameVersionRepository,
+		gameFileRepository:    gameFileRepository,
+		gameFileStorage:       gameFileStorage,
+	}
+}
+
+func (gf *GameFile) SaveGameFile(ctx context.Context, reader io.Reader, gameID values.GameID, fileType values.GameFileType, entryPoint values.GameFileEntryPoint) (*domain.GameFile, error) {
+	var gameFile *domain.GameFile
+	err := gf.db.Transaction(ctx, nil, func(ctx context.Context) error {
+		_, err := gf.gameRepository.GetGame(ctx, gameID, repository.LockTypeRecord)
+		if errors.Is(err, repository.ErrRecordNotFound) {
+			return service.ErrInvalidGameID
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get game: %w", err)
+		}
+
+		gameVersion, err := gf.gameVersionRepository.GetLatestGameVersion(ctx, gameID, repository.LockTypeRecord)
+		if errors.Is(err, repository.ErrRecordNotFound) {
+			return service.ErrNoGameVersion
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get latest game version: %w", err)
+		}
+
+		buf := bytes.NewBuffer(nil)
+		tr := io.TeeReader(reader, buf)
+		hash, err := values.NewGameFileHash(tr)
+		if err != nil {
+			return fmt.Errorf("failed to get hash: %w", err)
+		}
+
+		_, err = io.ReadAll(tr)
+		if err != nil {
+			return fmt.Errorf("failed to read all: %w", err)
+		}
+
+		gameFileID := values.NewGameFileID()
+		gameFile = domain.NewGameFile(gameFileID, fileType, entryPoint, hash)
+
+		err = gf.gameFileRepository.SaveGameFile(ctx, gameVersion.GetID(), gameFile)
+		if err != nil {
+			return fmt.Errorf("failed to save game file(repository): %w", err)
+		}
+
+		err = gf.gameFileStorage.SaveGameFile(ctx, buf, gameFile)
+		if err != nil {
+			return fmt.Errorf("failed to save game file(storage): %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed in transaction: %w", err)
+	}
+
+	return gameFile, nil
+}
+
+func (gf *GameFile) GetGameFile(ctx context.Context, writer io.Writer, gameID values.GameID, environment *values.LauncherEnvironment) (*domain.GameFile, error) {
+	_, err := gf.gameRepository.GetGame(ctx, gameID, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, service.ErrInvalidGameID
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get game: %w", err)
+	}
+
+	gameVersion, err := gf.gameVersionRepository.GetLatestGameVersion(ctx, gameID, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, service.ErrNoGameVersion
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest game version: %w", err)
+	}
+
+	gameFiles, err := gf.gameFileRepository.GetGameFiles(ctx, gameVersion.GetID(), environment.AcceptGameFileTypes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get game file: %w", err)
+	}
+
+	gameFileTypeMap := make(map[values.GameFileType]*domain.GameFile)
+	for _, gameFile := range gameFiles {
+		gameFileTypeMap[gameFile.GetFileType()] = gameFile
+	}
+
+	var gameFile *domain.GameFile
+	if winGameFile, ok := gameFileTypeMap[values.GameFileTypeWindows]; ok {
+		gameFile = winGameFile
+	} else if macGameFile, ok := gameFileTypeMap[values.GameFileTypeMac]; ok {
+		gameFile = macGameFile
+	} else if jarGameFile, ok := gameFileTypeMap[values.GameFileTypeJar]; ok {
+		gameFile = jarGameFile
+	} else {
+		return nil, service.ErrNoGameFile
+	}
+
+	err = gf.gameFileStorage.GetGameFile(ctx, writer, gameFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get game file(storage): %w", err)
+	}
+
+	return gameFile, nil
+}

--- a/src/service/v1/game_file_test.go
+++ b/src/service/v1/game_file_test.go
@@ -1,0 +1,684 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/repository"
+	mockRepository "github.com/traPtitech/trap-collection-server/src/repository/mock"
+	"github.com/traPtitech/trap-collection-server/src/service"
+	mockStorage "github.com/traPtitech/trap-collection-server/src/storage/mock"
+)
+
+func TestSaveGameFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mockRepository.NewMockDB(ctrl)
+	mockGameRepository := mockRepository.NewMockGame(ctrl)
+	mockGameVersionRepository := mockRepository.NewMockGameVersion(ctrl)
+	mockGameFileRepository := mockRepository.NewMockGameFile(ctrl)
+
+	type test struct {
+		description                   string
+		reader                        *bytes.Buffer
+		gameID                        values.GameID
+		fileType                      values.GameFileType
+		entryPoint                    values.GameFileEntryPoint
+		GetGameErr                    error
+		executeGetLatestGameVersion   bool
+		gameVersion                   *domain.GameVersion
+		GetLatestGameVersionErr       error
+		executeRepositorySaveGameFile bool
+		repositorySaveGameFileErr     error
+		executeStorageSaveGameVersion bool
+		storageSaveGameVersionErr     error
+		hash                          values.GameFileHash
+		isErr                         bool
+		err                           error
+	}
+
+	gameID := values.NewGameID()
+
+	testCases := []test{
+		{
+			description:                 "特に問題ないのでエラーなし",
+			reader:                      bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			fileType:                    values.GameFileTypeJar,
+			entryPoint:                  values.NewGameFileEntryPoint("/path/to/file"),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositorySaveGameFile: true,
+			executeStorageSaveGameVersion: true,
+			hash:                          values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+		},
+		{
+			description: "ゲームが存在しないのでエラー",
+			reader:      bytes.NewBufferString("test"),
+			gameID:      gameID,
+			fileType:    values.GameFileTypeJar,
+			entryPoint:  values.NewGameFileEntryPoint("/path/to/file"),
+			GetGameErr:  repository.ErrRecordNotFound,
+			isErr:       true,
+			err:         service.ErrInvalidGameID,
+		},
+		{
+			description: "GetGameがエラーなのでエラー",
+			reader:      bytes.NewBufferString("test"),
+			gameID:      gameID,
+			fileType:    values.GameFileTypeJar,
+			entryPoint:  values.NewGameFileEntryPoint("/path/to/file"),
+			GetGameErr:  errors.New("error"),
+			isErr:       true,
+		},
+		{
+			description:                 "ゲームバージョンが存在しないのでエラー",
+			reader:                      bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			fileType:                    values.GameFileTypeJar,
+			entryPoint:                  values.NewGameFileEntryPoint("/path/to/file"),
+			executeGetLatestGameVersion: true,
+			GetLatestGameVersionErr:     repository.ErrRecordNotFound,
+			isErr:                       true,
+			err:                         service.ErrNoGameVersion,
+		},
+		{
+			description:                 "GetLatestGameVersionがエラーなのでエラー",
+			gameID:                      gameID,
+			fileType:                    values.GameFileTypeJar,
+			entryPoint:                  values.NewGameFileEntryPoint("/path/to/file"),
+			executeGetLatestGameVersion: true,
+			GetLatestGameVersionErr:     errors.New("error"),
+			isErr:                       true,
+		},
+		{
+			description:                 "repositoryのSaveGameFileがエラーなのでエラー",
+			reader:                      bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			fileType:                    values.GameFileTypeJar,
+			entryPoint:                  values.NewGameFileEntryPoint("/path/to/file"),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositorySaveGameFile: true,
+			repositorySaveGameFileErr:     errors.New("error"),
+			isErr:                         true,
+		},
+		{
+			description:                 "storageのSaveGameVersionがエラーなのでエラー",
+			reader:                      bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			fileType:                    values.GameFileTypeJar,
+			entryPoint:                  values.NewGameFileEntryPoint("/path/to/file"),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositorySaveGameFile: true,
+			executeStorageSaveGameVersion: true,
+			storageSaveGameVersionErr:     errors.New("error"),
+			isErr:                         true,
+		},
+		{
+			description:                 "fileTypeがwindowsでもエラーなし",
+			reader:                      bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			fileType:                    values.GameFileTypeWindows,
+			entryPoint:                  values.NewGameFileEntryPoint("/path/to/file"),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositorySaveGameFile: true,
+			executeStorageSaveGameVersion: true,
+			hash:                          values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+		},
+		{
+			description:                 "fileTypeがmacでもエラーなし",
+			reader:                      bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			fileType:                    values.GameFileTypeMac,
+			entryPoint:                  values.NewGameFileEntryPoint("/path/to/file"),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositorySaveGameFile: true,
+			executeStorageSaveGameVersion: true,
+			hash:                          values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+		},
+		{
+			description:                 "entryPointが空でもエラーなし",
+			reader:                      bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			fileType:                    values.GameFileTypeJar,
+			entryPoint:                  values.NewGameFileEntryPoint(""),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositorySaveGameFile: true,
+			executeStorageSaveGameVersion: true,
+			hash:                          values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+		},
+		{
+			description:                 "データが大きくてもエラーなし",
+			reader:                      bytes.NewBufferString(strings.Repeat("a", 1e7)),
+			gameID:                      gameID,
+			fileType:                    values.GameFileTypeJar,
+			entryPoint:                  values.NewGameFileEntryPoint("/path/to/file"),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositorySaveGameFile: true,
+			executeStorageSaveGameVersion: true,
+			hash:                          values.NewGameFileHashFromBytes([]byte{0x70, 0x95, 0xba, 0xe0, 0x98, 0x25, 0x9e, 0xd, 0xda, 0x4b, 0x7a, 0xcc, 0x62, 0x4d, 0xe4, 0xe2}),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			mockGameFileStorage := mockStorage.NewGameFile(ctrl, buf)
+
+			gameFileService := NewGameFile(
+				mockDB,
+				mockGameRepository,
+				mockGameVersionRepository,
+				mockGameFileRepository,
+				mockGameFileStorage,
+			)
+
+			mockGameRepository.
+				EXPECT().
+				GetGame(gomock.Any(), gameID, repository.LockTypeRecord).
+				Return(nil, testCase.GetGameErr)
+
+			if testCase.executeGetLatestGameVersion {
+				mockGameVersionRepository.
+					EXPECT().
+					GetLatestGameVersion(gomock.Any(), gameID, repository.LockTypeRecord).
+					Return(testCase.gameVersion, testCase.GetLatestGameVersionErr)
+			}
+
+			if testCase.executeRepositorySaveGameFile {
+				mockGameFileRepository.
+					EXPECT().
+					SaveGameFile(gomock.Any(), testCase.gameVersion.GetID(), gomock.Any()).
+					Return(testCase.repositorySaveGameFileErr)
+			}
+
+			if testCase.executeStorageSaveGameVersion {
+				mockGameFileStorage.
+					EXPECT().
+					SaveGameFile(gomock.Any(), gomock.Any()).
+					Return(testCase.storageSaveGameVersionErr)
+			}
+
+			var expectBytes []byte
+			if testCase.reader != nil {
+				expectBytes = testCase.reader.Bytes()
+			}
+
+			gameFile, err := gameFileService.SaveGameFile(ctx, testCase.reader, testCase.gameID, testCase.fileType, testCase.entryPoint)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, testCase.fileType, gameFile.GetFileType())
+			assert.Equal(t, testCase.entryPoint, gameFile.GetEntryPoint())
+			assert.Equal(t, testCase.hash, gameFile.GetHash())
+			assert.Equal(t, expectBytes, buf.Bytes())
+		})
+	}
+}
+
+func TestGetGameFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mockRepository.NewMockDB(ctrl)
+	mockGameRepository := mockRepository.NewMockGame(ctrl)
+	mockGameVersionRepository := mockRepository.NewMockGameVersion(ctrl)
+	mockGameFileRepository := mockRepository.NewMockGameFile(ctrl)
+
+	type test struct {
+		description                  string
+		fileContent                  *bytes.Buffer
+		gameID                       values.GameID
+		environment                  *values.LauncherEnvironment
+		GetGameErr                   error
+		executeGetLatestGameVersion  bool
+		gameVersion                  *domain.GameVersion
+		GetLatestGameVersionErr      error
+		executeRepositoryGetGameFile bool
+		gameFiles                    []*domain.GameFile
+		repositoryGetGameFileErr     error
+		gameFile                     *domain.GameFile
+		executeStorageGetGameFile    bool
+		storageGetGameFileErr        error
+		isErr                        bool
+		err                          error
+	}
+
+	gameID := values.NewGameID()
+	gameFileID1 := values.NewGameFileID()
+	gameFileID2 := values.NewGameFileID()
+
+	testCases := []test{
+		{
+			description:                 "特に問題ないのでエラーなし",
+			fileContent:                 bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositoryGetGameFile: true,
+			gameFiles: []*domain.GameFile{
+				domain.NewGameFile(
+					gameFileID1,
+					values.GameFileTypeJar,
+					"/path/to/game.jar",
+					values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+				),
+			},
+			gameFile: domain.NewGameFile(
+				gameFileID1,
+				values.GameFileTypeJar,
+				"/path/to/game.jar",
+				values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+			),
+			executeStorageGetGameFile: true,
+		},
+		{
+			description: "ゲームが存在しないのでエラー",
+			fileContent: bytes.NewBufferString("test"),
+			gameID:      gameID,
+			environment: values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			GetGameErr:  repository.ErrRecordNotFound,
+			isErr:       true,
+			err:         service.ErrInvalidGameID,
+		},
+		{
+			description: "GetGameがエラーなのでエラー",
+			fileContent: bytes.NewBufferString("test"),
+			gameID:      gameID,
+			environment: values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			GetGameErr:  errors.New("error"),
+			isErr:       true,
+		},
+		{
+			description:                 "ゲームバージョンが存在しないのでエラー",
+			fileContent:                 bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			executeGetLatestGameVersion: true,
+			GetLatestGameVersionErr:     repository.ErrRecordNotFound,
+			isErr:                       true,
+			err:                         service.ErrNoGameVersion,
+		},
+		{
+			description:                 "GetLatestGameVersionがエラーなのでエラー",
+			fileContent:                 bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			executeGetLatestGameVersion: true,
+			GetLatestGameVersionErr:     errors.New("error"),
+			isErr:                       true,
+		},
+		{
+			description:                 "repositoryのGetGameFileがエラーなのでエラー",
+			fileContent:                 bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositoryGetGameFile: true,
+			repositoryGetGameFileErr:     errors.New("error"),
+			isErr:                        true,
+		},
+		{
+			description:                 "storageのGetGameFileがエラーなのでエラー",
+			fileContent:                 bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositoryGetGameFile: true,
+			gameFiles: []*domain.GameFile{
+				domain.NewGameFile(
+					gameFileID1,
+					values.GameFileTypeJar,
+					"/path/to/game.jar",
+					values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+				),
+			},
+			gameFile: domain.NewGameFile(
+				gameFileID1,
+				values.GameFileTypeJar,
+				"/path/to/game.jar",
+				values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+			),
+			executeStorageGetGameFile: true,
+			storageGetGameFileErr:     errors.New("error"),
+			isErr:                     true,
+		},
+		{
+			description:                 "ゲームファイルが存在しないのでエラー",
+			fileContent:                 bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositoryGetGameFile: true,
+			gameFiles:                    []*domain.GameFile{},
+			isErr:                        true,
+			err:                          service.ErrNoGameFile,
+		},
+		{
+			description:                 "windows用のファイルが存在すればjarよりそちらを優先する",
+			fileContent:                 bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositoryGetGameFile: true,
+			gameFiles: []*domain.GameFile{
+				domain.NewGameFile(
+					gameFileID1,
+					values.GameFileTypeJar,
+					"/path/to/game.jar",
+					values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+				),
+				domain.NewGameFile(
+					gameFileID2,
+					values.GameFileTypeWindows,
+					"/path/to/game.exe",
+					values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+				),
+			},
+			gameFile: domain.NewGameFile(
+				gameFileID2,
+				values.GameFileTypeWindows,
+				"/path/to/game.exe",
+				values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+			),
+			executeStorageGetGameFile: true,
+		},
+		{
+			description:                 "順番に関わらずwindows用のファイルが存在すればjarよりそちらを優先する",
+			fileContent:                 bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositoryGetGameFile: true,
+			gameFiles: []*domain.GameFile{
+				domain.NewGameFile(
+					gameFileID2,
+					values.GameFileTypeWindows,
+					"/path/to/game.exe",
+					values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+				),
+				domain.NewGameFile(
+					gameFileID1,
+					values.GameFileTypeJar,
+					"/path/to/game.jar",
+					values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+				),
+			},
+			gameFile: domain.NewGameFile(
+				gameFileID2,
+				values.GameFileTypeWindows,
+				"/path/to/game.exe",
+				values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+			),
+			executeStorageGetGameFile: true,
+		},
+		{
+			description:                 "mac用のファイルが存在すればjarよりそちらを優先する",
+			fileContent:                 bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSMac),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositoryGetGameFile: true,
+			gameFiles: []*domain.GameFile{
+				domain.NewGameFile(
+					gameFileID1,
+					values.GameFileTypeJar,
+					"/path/to/game.jar",
+					values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+				),
+				domain.NewGameFile(
+					gameFileID2,
+					values.GameFileTypeMac,
+					"/path/to/game.app",
+					values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+				),
+			},
+			gameFile: domain.NewGameFile(
+				gameFileID2,
+				values.GameFileTypeMac,
+				"/path/to/game.app",
+				values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+			),
+			executeStorageGetGameFile: true,
+		},
+		{
+			description:                 "順番に関わらずmac用のファイルが存在すればjarよりそちらを優先する",
+			fileContent:                 bytes.NewBufferString("test"),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSMac),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositoryGetGameFile: true,
+			gameFiles: []*domain.GameFile{
+				domain.NewGameFile(
+					gameFileID2,
+					values.GameFileTypeMac,
+					"/path/to/game.app",
+					values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+				),
+				domain.NewGameFile(
+					gameFileID1,
+					values.GameFileTypeJar,
+					"/path/to/game.jar",
+					values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+				),
+			},
+			gameFile: domain.NewGameFile(
+				gameFileID2,
+				values.GameFileTypeMac,
+				"/path/to/game.app",
+				values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
+			),
+			executeStorageGetGameFile: true,
+		},
+		{
+			description:                 "ファイルが大きくても問題なし",
+			fileContent:                 bytes.NewBufferString(strings.Repeat("a", 1e7)),
+			gameID:                      gameID,
+			environment:                 values.NewLauncherEnvironment(values.LauncherEnvironmentOSWindows),
+			executeGetLatestGameVersion: true,
+			gameVersion: domain.NewGameVersion(
+				values.NewGameVersionID(),
+				"v1.0.0",
+				"リリース",
+				time.Now(),
+			),
+			executeRepositoryGetGameFile: true,
+			gameFiles: []*domain.GameFile{
+				domain.NewGameFile(
+					gameFileID1,
+					values.GameFileTypeJar,
+					"/path/to/game.jar",
+					values.NewGameFileHashFromBytes([]byte{0x70, 0x95, 0xba, 0xe0, 0x98, 0x25, 0x9e, 0xd, 0xda, 0x4b, 0x7a, 0xcc, 0x62, 0x4d, 0xe4, 0xe2}),
+				),
+			},
+			gameFile: domain.NewGameFile(
+				gameFileID1,
+				values.GameFileTypeJar,
+				"/path/to/game.jar",
+				values.NewGameFileHashFromBytes([]byte{0x70, 0x95, 0xba, 0xe0, 0x98, 0x25, 0x9e, 0xd, 0xda, 0x4b, 0x7a, 0xcc, 0x62, 0x4d, 0xe4, 0xe2}),
+			),
+			executeStorageGetGameFile: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			mockGameFileStorage := mockStorage.NewGameFile(ctrl, testCase.fileContent)
+
+			gameFileService := NewGameFile(
+				mockDB,
+				mockGameRepository,
+				mockGameVersionRepository,
+				mockGameFileRepository,
+				mockGameFileStorage,
+			)
+
+			mockGameRepository.
+				EXPECT().
+				GetGame(gomock.Any(), gameID, repository.LockTypeNone).
+				Return(nil, testCase.GetGameErr)
+
+			if testCase.executeGetLatestGameVersion {
+				mockGameVersionRepository.
+					EXPECT().
+					GetLatestGameVersion(gomock.Any(), gameID, repository.LockTypeNone).
+					Return(testCase.gameVersion, testCase.GetLatestGameVersionErr)
+			}
+
+			if testCase.executeRepositoryGetGameFile {
+				mockGameFileRepository.
+					EXPECT().
+					GetGameFiles(gomock.Any(), testCase.gameVersion.GetID(), gomock.Any()).
+					Return(testCase.gameFiles, testCase.repositoryGetGameFileErr)
+			}
+
+			if testCase.executeStorageGetGameFile {
+				mockGameFileStorage.
+					EXPECT().
+					GetGameFile(gomock.Any(), gomock.Any()).
+					Return(testCase.storageGetGameFileErr)
+			}
+
+			var expectBytes []byte
+			if testCase.fileContent != nil {
+				expectBytes = testCase.fileContent.Bytes()
+			}
+
+			buf := bytes.NewBuffer(nil)
+			gameFile, err := gameFileService.GetGameFile(ctx, buf, testCase.gameID, testCase.environment)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, *testCase.gameFile, *gameFile)
+			assert.Equal(t, expectBytes, buf.Bytes())
+		})
+	}
+}

--- a/src/storage/game_file.go
+++ b/src/storage/game_file.go
@@ -1,0 +1,13 @@
+package storage
+
+import (
+	"context"
+	"io"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+)
+
+type GameFile interface {
+	SaveGameFile(ctx context.Context, reader io.Reader, file *domain.GameFile) error
+	GetGameFile(ctx context.Context, writer io.Writer, file *domain.GameFile) error
+}

--- a/src/storage/mock/game_file.go
+++ b/src/storage/mock/game_file.go
@@ -1,0 +1,88 @@
+package mock
+
+import (
+	"bytes"
+	context "context"
+	io "io"
+	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	domain "github.com/traPtitech/trap-collection-server/src/domain"
+)
+
+// GameFile is a mock of GameFile interface.
+type GameFile struct {
+	ctrl     *gomock.Controller
+	recorder *GameFileMockRecorder
+	buf      *bytes.Buffer
+}
+
+// GameFileMockRecorder is the mock recorder for MockGameFile.
+type GameFileMockRecorder struct {
+	mock *GameFile
+}
+
+// NewGameFile creates a new mock instance.
+func NewGameFile(ctrl *gomock.Controller, buf *bytes.Buffer) *GameFile {
+	mock := &GameFile{ctrl: ctrl}
+	mock.recorder = &GameFileMockRecorder{mock}
+	mock.buf = buf
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *GameFile) EXPECT() *GameFileMockRecorder {
+	return m.recorder
+}
+
+// GetGameFile mocks base method.
+func (m *GameFile) GetGameFile(ctx context.Context, writer io.Writer, file *domain.GameFile) error {
+	ret0 := m.getGameFile(ctx, file)
+
+	_, err := io.Copy(writer, m.buf)
+	if err != nil {
+		m.ctrl.T.Fatalf("unexpected error copying from buffer: %v", err)
+	}
+
+	return ret0
+}
+
+// GetGameFile mocks base method.
+func (m *GameFile) getGameFile(ctx context.Context, file *domain.GameFile) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGameFile", ctx, file)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetGameFile indicates an expected call of GetGameFile.
+func (mr *GameFileMockRecorder) GetGameFile(ctx, file interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGameFile", reflect.TypeOf((*GameFile)(nil).GetGameFile), ctx, file)
+}
+
+// SaveGameFile mocks base method.
+func (m *GameFile) SaveGameFile(ctx context.Context, reader io.Reader, file *domain.GameFile) error {
+	ret0 := m.saveGameFile(ctx, file)
+
+	_, err := io.Copy(m.buf, reader)
+	if err != nil {
+		m.ctrl.T.Fatalf("unexpected error copying to buffer: %v", err)
+	}
+
+	return ret0
+}
+
+func (m *GameFile) saveGameFile(ctx context.Context, file *domain.GameFile) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveGameFile", ctx, file)
+	ret0, _ := ret[0].(error)
+
+	return ret0
+}
+
+// SaveGameFile indicates an expected call of SaveGameFile.
+func (mr *GameFileMockRecorder) SaveGameFile(ctx, file interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveGameFile", reflect.TypeOf((*GameFile)(nil).saveGameFile), ctx, file)
+}


### PR DESCRIPTION
#205 でのGameFileサービス実装した際にGameVersionインターフェイスに変更が発生し、コンパイルが通らなくなったのでmainへの取り込みを保留していた。
#206 でgorm2実装の修正が完了したので取り込む。