### PR TITLE
ImageドメインにcreatedAt追加

### DIFF
--- a/src/domain/game_image.go
+++ b/src/domain/game_image.go
@@ -1,6 +1,10 @@
 package domain
 
-import "github.com/traPtitech/trap-collection-server/src/domain/values"
+import (
+	"time"
+
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
 
 /*
 	GameImage
@@ -9,15 +13,18 @@ import "github.com/traPtitech/trap-collection-server/src/domain/values"
 type GameImage struct {
 	id        values.GameImageID
 	imageType values.GameImageType
+	createdAt time.Time
 }
 
 func NewGameImage(
 	id values.GameImageID,
 	imageType values.GameImageType,
+	createdAt time.Time,
 ) *GameImage {
 	return &GameImage{
 		id:        id,
 		imageType: imageType,
+		createdAt: createdAt,
 	}
 }
 
@@ -27,4 +34,8 @@ func (gi *GameImage) GetID() values.GameImageID {
 
 func (gi *GameImage) GetType() values.GameImageType {
 	return gi.imageType
+}
+
+func (gi *GameImage) GetCreatedAt() time.Time {
+	return gi.createdAt
 }

--- a/src/repository/gorm2/game_image.go
+++ b/src/repository/gorm2/game_image.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/traPtitech/trap-collection-server/src/domain"
@@ -109,7 +108,7 @@ func (gi *GameImage) SaveGameImage(ctx context.Context, gameID values.GameID, im
 		ID:          uuid.UUID(image.GetID()),
 		GameID:      uuid.UUID(gameID),
 		ImageTypeID: imageTypeID,
-		CreatedAt:   time.Now(),
+		CreatedAt:   image.GetCreatedAt(),
 	}).Error
 	if err != nil {
 		return fmt.Errorf("failed to create game image: %w", err)
@@ -157,5 +156,6 @@ func (gi *GameImage) GetLatestGameImage(ctx context.Context, gameID values.GameI
 	return domain.NewGameImage(
 		values.GameImageIDFromUUID(image.ID),
 		imageType,
+		image.CreatedAt,
 	), nil
 }

--- a/src/repository/gorm2/game_image_test.go
+++ b/src/repository/gorm2/game_image_test.go
@@ -175,6 +175,8 @@ func TestSaveGameImage(t *testing.T) {
 		imageTypeMap[imageType.Name] = imageType.ID
 	}
 
+	now := time.Now()
+
 	testCases := []test{
 		{
 			description: "特に問題ないので問題なし",
@@ -182,6 +184,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				imageID1,
 				values.GameImageTypeJpeg,
+				now,
 			),
 			beforeImages: []GameImageTable{},
 			expectImages: []GameImageTable{
@@ -189,7 +192,7 @@ func TestSaveGameImage(t *testing.T) {
 					ID:          uuid.UUID(imageID1),
 					GameID:      uuid.UUID(gameID1),
 					ImageTypeID: imageTypeMap[gameImageTypeJpeg],
-					CreatedAt:   time.Now(),
+					CreatedAt:   now,
 				},
 			},
 		},
@@ -199,6 +202,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				imageID2,
 				values.GameImageTypePng,
+				now,
 			),
 			beforeImages: []GameImageTable{},
 			expectImages: []GameImageTable{
@@ -206,7 +210,7 @@ func TestSaveGameImage(t *testing.T) {
 					ID:          uuid.UUID(imageID2),
 					GameID:      uuid.UUID(gameID2),
 					ImageTypeID: imageTypeMap[gameImageTypePng],
-					CreatedAt:   time.Now(),
+					CreatedAt:   now,
 				},
 			},
 		},
@@ -216,6 +220,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				imageID3,
 				values.GameImageTypeGif,
+				now,
 			),
 			beforeImages: []GameImageTable{},
 			expectImages: []GameImageTable{
@@ -223,7 +228,7 @@ func TestSaveGameImage(t *testing.T) {
 					ID:          uuid.UUID(imageID3),
 					GameID:      uuid.UUID(gameID3),
 					ImageTypeID: imageTypeMap[gameImageTypeGif],
-					CreatedAt:   time.Now(),
+					CreatedAt:   now,
 				},
 			},
 		},
@@ -233,6 +238,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				imageID4,
 				100,
+				now,
 			),
 			beforeImages: []GameImageTable{},
 			expectImages: []GameImageTable{},
@@ -244,13 +250,14 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				imageID5,
 				values.GameImageTypeJpeg,
+				now,
 			),
 			beforeImages: []GameImageTable{
 				{
 					ID:          uuid.UUID(imageID6),
 					GameID:      uuid.UUID(gameID5),
 					ImageTypeID: imageTypeMap[gameImageTypePng],
-					CreatedAt:   time.Now().Add(-10 * time.Hour),
+					CreatedAt:   now.Add(-10 * time.Hour),
 				},
 			},
 			expectImages: []GameImageTable{
@@ -258,13 +265,13 @@ func TestSaveGameImage(t *testing.T) {
 					ID:          uuid.UUID(imageID6),
 					GameID:      uuid.UUID(gameID5),
 					ImageTypeID: imageTypeMap[gameImageTypePng],
-					CreatedAt:   time.Now().Add(-10 * time.Hour),
+					CreatedAt:   now.Add(-10 * time.Hour),
 				},
 				{
 					ID:          uuid.UUID(imageID5),
 					GameID:      uuid.UUID(gameID5),
 					ImageTypeID: imageTypeMap[gameImageTypeJpeg],
-					CreatedAt:   time.Now(),
+					CreatedAt:   now,
 				},
 			},
 		},
@@ -274,13 +281,14 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				imageID7,
 				100,
+				now,
 			),
 			beforeImages: []GameImageTable{
 				{
 					ID:          uuid.UUID(imageID8),
 					GameID:      uuid.UUID(gameID6),
 					ImageTypeID: imageTypeMap[gameImageTypePng],
-					CreatedAt:   time.Now().Add(-10 * time.Hour),
+					CreatedAt:   now.Add(-10 * time.Hour),
 				},
 			},
 			expectImages: []GameImageTable{
@@ -288,7 +296,7 @@ func TestSaveGameImage(t *testing.T) {
 					ID:          uuid.UUID(imageID8),
 					GameID:      uuid.UUID(gameID6),
 					ImageTypeID: imageTypeMap[gameImageTypePng],
-					CreatedAt:   time.Now().Add(-10 * time.Hour),
+					CreatedAt:   now.Add(-10 * time.Hour),
 				},
 			},
 			isErr: true,
@@ -402,6 +410,8 @@ func TestGetLatestGameImage(t *testing.T) {
 		imageTypeMap[imageType.Name] = imageType.ID
 	}
 
+	now := time.Now()
+
 	testCases := []test{
 		{
 			description: "特に問題ないのでエラーなし",
@@ -412,12 +422,13 @@ func TestGetLatestGameImage(t *testing.T) {
 					ID:          uuid.UUID(imageID1),
 					GameID:      uuid.UUID(gameID1),
 					ImageTypeID: imageTypeMap[gameImageTypeJpeg],
-					CreatedAt:   time.Now(),
+					CreatedAt:   now,
 				},
 			},
 			expectImage: domain.NewGameImage(
 				imageID1,
 				values.GameImageTypeJpeg,
+				now,
 			),
 		},
 		{
@@ -429,12 +440,13 @@ func TestGetLatestGameImage(t *testing.T) {
 					ID:          uuid.UUID(imageID2),
 					GameID:      uuid.UUID(gameID2),
 					ImageTypeID: imageTypeMap[gameImageTypePng],
-					CreatedAt:   time.Now(),
+					CreatedAt:   now,
 				},
 			},
 			expectImage: domain.NewGameImage(
 				imageID2,
 				values.GameImageTypePng,
+				now,
 			),
 		},
 		{
@@ -446,12 +458,13 @@ func TestGetLatestGameImage(t *testing.T) {
 					ID:          uuid.UUID(imageID3),
 					GameID:      uuid.UUID(gameID3),
 					ImageTypeID: imageTypeMap[gameImageTypeGif],
-					CreatedAt:   time.Now(),
+					CreatedAt:   now,
 				},
 			},
 			expectImage: domain.NewGameImage(
 				imageID3,
 				values.GameImageTypeGif,
+				now,
 			),
 		},
 		{
@@ -471,18 +484,19 @@ func TestGetLatestGameImage(t *testing.T) {
 					ID:          uuid.UUID(imageID4),
 					GameID:      uuid.UUID(gameID5),
 					ImageTypeID: imageTypeMap[gameImageTypeJpeg],
-					CreatedAt:   time.Now().Add(-24 * time.Hour),
+					CreatedAt:   now.Add(-24 * time.Hour),
 				},
 				{
 					ID:          uuid.UUID(imageID5),
 					GameID:      uuid.UUID(gameID5),
 					ImageTypeID: imageTypeMap[gameImageTypePng],
-					CreatedAt:   time.Now(),
+					CreatedAt:   now,
 				},
 			},
 			expectImage: domain.NewGameImage(
 				imageID5,
 				values.GameImageTypePng,
+				time.Now(),
 			),
 		},
 		{
@@ -494,12 +508,13 @@ func TestGetLatestGameImage(t *testing.T) {
 					ID:          uuid.UUID(imageID6),
 					GameID:      uuid.UUID(gameID6),
 					ImageTypeID: imageTypeMap[gameImageTypeJpeg],
-					CreatedAt:   time.Now(),
+					CreatedAt:   now,
 				},
 			},
 			expectImage: domain.NewGameImage(
 				imageID6,
 				values.GameImageTypeJpeg,
+				now,
 			),
 		},
 	}
@@ -532,7 +547,9 @@ func TestGetLatestGameImage(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, *testCase.expectImage, *image)
+			assert.Equal(t, testCase.expectImage.GetID(), image.GetID())
+			assert.Equal(t, testCase.expectImage.GetType(), image.GetType())
+			assert.WithinDuration(t, testCase.expectImage.GetCreatedAt(), image.GetCreatedAt(), time.Second)
 		})
 	}
 }

--- a/src/service/v1/game_image.go
+++ b/src/service/v1/game_image.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/h2non/filetype"
 	"github.com/h2non/filetype/matchers"
@@ -74,6 +75,7 @@ func (gi *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, gameID
 		image := domain.NewGameImage(
 			values.NewGameImageID(),
 			imageType,
+			time.Now(),
 		)
 
 		err = gi.gameImageRepository.SaveGameImage(ctx, gameID, image)

--- a/src/service/v1/game_image_test.go
+++ b/src/service/v1/game_image_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -239,6 +240,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			executeGetGameImage: true,
 		},
@@ -268,6 +270,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			executeGetGameImage: true,
 		},
@@ -280,6 +283,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			executeGetGameImage: true,
 		},
@@ -292,6 +296,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			executeGetGameImage: true,
 		},
@@ -323,6 +328,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			executeGetGameImage: true,
 			GetGameImageErr:     errors.New("error"),

--- a/src/storage/local/game_image_test.go
+++ b/src/storage/local/game_image_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			reader: bytes.NewBufferString("a"),
 		},
@@ -62,6 +64,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			reader:      bytes.NewBufferString("b"),
 			isFileExist: true,
@@ -150,6 +153,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			isFileExist: true,
 			fileContent: bytes.NewBufferString("b"),
@@ -159,6 +163,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			isErr: true,
 			err:   storage.ErrNotFound,

--- a/src/storage/swift/game_image_test.go
+++ b/src/storage/swift/game_image_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 		},
 		{
@@ -63,6 +65,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypePng,
+				time.Now(),
 			),
 		},
 		{
@@ -70,6 +73,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeGif,
+				time.Now(),
 			),
 		},
 		{
@@ -77,6 +81,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				100,
+				time.Now(),
 			),
 			isErr: true,
 		},
@@ -85,6 +90,7 @@ func TestSaveGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			isFileExist: true,
 			isErr:       true,
@@ -196,6 +202,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			isFileExist: true,
 		},
@@ -204,6 +211,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypePng,
+				time.Now(),
 			),
 			isFileExist: true,
 		},
@@ -212,6 +220,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeGif,
+				time.Now(),
 			),
 			isFileExist: true,
 		},
@@ -220,6 +229,7 @@ func TestGetGameImage(t *testing.T) {
 			image: domain.NewGameImage(
 				values.NewGameImageID(),
 				values.GameImageTypeJpeg,
+				time.Now(),
 			),
 			isErr: true,
 			err:   storage.ErrNotFound,
@@ -301,6 +311,7 @@ func TestImageKey(t *testing.T) {
 		image := domain.NewGameImage(
 			imageID,
 			values.GameImageType(rand.Intn(3)),
+			time.Now(),
 		)
 
 		key := gameImageStorage.imageKey(image)


### PR DESCRIPTION
ImageドメインにcreatedAtを入れていなかったが、ランチャー起動時に取得するゲームの画像などの更新情報取得時に必要で、アプリケーション内で扱う情報だったので追加した。