### PR TITLE
expiresInを1h->24hに

### DIFF
--- a/src/service/v1/launcher_auth.go
+++ b/src/service/v1/launcher_auth.go
@@ -12,7 +12,7 @@ import (
 	"github.com/traPtitech/trap-collection-server/src/service"
 )
 
-const expiresIn = 3600
+const expiresIn = 86400
 
 type LauncherAuth struct {
 	db                        repository.DB


### PR DESCRIPTION
access tokenの有効期限を1hから24hに変更した。
これ以降新たに発行されるaccess tokenの有効期限は24時間になる。