### PR TITLE
ストレージ切り替えのバグ修正

### DIFF
--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -34,6 +34,8 @@ RUN go generate ./... \
 
 FROM alpine:3.15.0
 
+WORKDIR /go/src/github.com/traPtitech/trap-collection-server
+
 RUN apk --update --no-cache add tzdata \
   && cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
   && apk del tzdata \

--- a/main.go
+++ b/main.go
@@ -161,6 +161,7 @@ func main() {
 
 	newAPI, err := src.InjectAPI(&src.Config{
 		IsProduction:    common.IsProduction(isProduction),
+		IsSwift:         common.IsSwift(isSwift),
 		SessionKey:      "sessions",
 		SessionSecret:   common.SessionSecret(secret),
 		TraQBaseURL:     common.TraQBaseURL(traQBaseURL),


### PR DESCRIPTION
ストレージのlocalからオブジェクトストレージへの切り替えが #231 以降機能しておらず、staging環境でobject strageにデータが保存されていなかった。
また、workdirが設定されていなかったために/にcacheディレクトリが作られ、cacheの引き継ぎができていなかった。