### PR TITLE
codecovのpath修正

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -132,7 +132,7 @@ jobs:
           key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
-      - run: go test ./src/... -v -coverprofile=../coverage.txt -race -vet=off
+      - run: go test ./src/... -v -coverprofile=./coverage.txt -race -vet=off
         env:
           COLLECTION_ENV: production
           DB_USERNAME: root


### PR DESCRIPTION
codecov.txtのパスが #248 以降誤っており、codecovが正常に動いていなかった。