### PR TITLE
アクセストークンのメトリクス、別に間違っていなかった

### DIFF
--- a/src/repository/gorm2/metrics.go
+++ b/src/repository/gorm2/metrics.go
@@ -147,7 +147,7 @@ func (mc *MetricsCollector) collectAccessTokenMetrics(ctx context.Context, p *go
 		Session(&gorm.Session{}).
 		Unscoped().
 		Model(&LauncherSessionTable{}).
-		Select("deleted_at IS NOT NULL OR expires_at < ? AS is_deleted, count(*) as count", time.Now().Add(-24*time.Hour)).
+		Select("deleted_at IS NOT NULL OR expires_at < ? AS is_deleted, count(*) as count", time.Now()).
 		Group("is_deleted").
 		Find(&accessTokenCounts).Error
 	if err != nil {

--- a/src/storage/swift/client_test.go
+++ b/src/storage/swift/client_test.go
@@ -60,6 +60,8 @@ func newTestClient(ctx context.Context, containerName common.SwiftContainer, cac
 }
 
 func TestSaveFile(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	client, err := newTestClient(
@@ -185,6 +187,8 @@ func TestSaveFile(t *testing.T) {
 }
 
 func TestLoadFile(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	client, err := newTestClient(

--- a/src/storage/swift/game_file_test.go
+++ b/src/storage/swift/game_file_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestSaveGameFile(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	client, err := newTestClient(
@@ -107,6 +109,8 @@ func TestSaveGameFile(t *testing.T) {
 }
 
 func TestGetGameFile(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	client, err := newTestClient(

--- a/src/storage/swift/game_image_test.go
+++ b/src/storage/swift/game_image_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestSaveGameImage(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	client, err := newTestClient(
@@ -110,6 +112,8 @@ func TestSaveGameImage(t *testing.T) {
 }
 
 func TestGetGameImage(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	client, err := newTestClient(

--- a/src/storage/swift/game_video_test.go
+++ b/src/storage/swift/game_video_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestSaveGameVideo(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	client, err := newTestClient(
@@ -124,6 +126,8 @@ func TestSaveGameVideo(t *testing.T) {
 }
 
 func TestGetGameVideo(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	client, err := newTestClient(


### PR DESCRIPTION
逆に間違ったものにしてしまっているので戻す。