### PR TITLE
PipeReaderのClose忘れ

### DIFF
--- a/generate/controller-api.mustache
+++ b/generate/controller-api.mustache
@@ -54,6 +54,7 @@ func {{baseName}}Handler({{classname}} {{classname}}) echo.HandlerFunc {
     }{{^isResponseFile}}{{#returnType}}
     return c.JSON(http.StatusOK, res){{/returnType}}{{^returnType}}
     return c.NoContent(http.StatusOK){{/returnType}}{{/isResponseFile}}{{#isResponseFile}}
+    defer res.Close()
     return c.Stream(http.StatusOK, {{#produces.0}}"{{mediaType}}"{{/produces.0}}, res){{/isResponseFile}}
   }
 }{{/operation}}{{/operations}}

--- a/generate/generator.groovy
+++ b/generate/generator.groovy
@@ -11,9 +11,9 @@ class CollectionCodegen extends GoGinServerCodegen {
   CollectionCodegen() {
     super()
     this.apiPath = "openapi"
-    this.typeMapping.put("File", "ioReader");
-    this.typeMapping.put("file", "ioReader");
-    this.typeMapping.put("binary", "ioReader");
+    this.typeMapping.put("File", "ioReadCloser");
+    this.typeMapping.put("file", "ioReadCloser");
+    this.typeMapping.put("binary", "ioReadCloser");
   }
 
   @Override

--- a/generate/interfaces.mustache
+++ b/generate/interfaces.mustache
@@ -10,7 +10,7 @@ import (
   "github.com/gorilla/sessions"
 )
 
-type ioReader = io.Reader
+type ioReadCloser = io.ReadCloser
 type multipartFile = multipart.File
 type sessionsSession = sessions.Session
 var getSession = session.Get

--- a/src/handler/v1/game_file.go
+++ b/src/handler/v1/game_file.go
@@ -85,7 +85,7 @@ func (gf *GameFile) PostFile(strGameID string, strEntryPoint string, file multip
 	}, nil
 }
 
-func (gf *GameFile) GetGameFile(strGameID string, strOperatingSystem string) (io.Reader, error) {
+func (gf *GameFile) GetGameFile(strGameID string, strOperatingSystem string) (io.ReadCloser, error) {
 	ctx := context.Background()
 
 	uuidGameID, err := uuid.Parse(strGameID)

--- a/src/handler/v1/game_file_test.go
+++ b/src/handler/v1/game_file_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bytes"
 	"errors"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -338,7 +339,7 @@ func TestGetGameFile(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			r := bytes.NewReader([]byte("a"))
+			r := io.NopCloser(bytes.NewReader([]byte("a")))
 
 			if testCase.executeGetGameFile {
 				mockGameFileService.

--- a/src/handler/v1/game_image.go
+++ b/src/handler/v1/game_image.go
@@ -49,7 +49,7 @@ func (gi *GameImage) PostImage(strGameID string, image multipart.File) error {
 	return nil
 }
 
-func (gi *GameImage) GetImage(strGameID string) (io.Reader, error) {
+func (gi *GameImage) GetImage(strGameID string) (io.ReadCloser, error) {
 	ctx := context.Background()
 
 	uuidGameID, err := uuid.Parse(strGameID)

--- a/src/handler/v1/game_image_test.go
+++ b/src/handler/v1/game_image_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bytes"
 	"errors"
+	"io"
 	"net/http"
 	"testing"
 
@@ -192,7 +193,7 @@ func TestGetImage(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			r := bytes.NewReader([]byte("a"))
+			r := io.NopCloser(bytes.NewReader([]byte("a")))
 
 			if testCase.executeGetGameImage {
 				mockGameImageService.

--- a/src/handler/v1/game_video.go
+++ b/src/handler/v1/game_video.go
@@ -49,7 +49,7 @@ func (gv *GameVideo) PostVideo(strGameID string, video multipart.File) error {
 	return nil
 }
 
-func (gv *GameVideo) GetVideo(strGameID string) (io.Reader, error) {
+func (gv *GameVideo) GetVideo(strGameID string) (io.ReadCloser, error) {
 	ctx := context.Background()
 
 	uuidGameID, err := uuid.Parse(strGameID)

--- a/src/handler/v1/game_video_test.go
+++ b/src/handler/v1/game_video_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bytes"
 	"errors"
+	"io"
 	"net/http"
 	"testing"
 
@@ -192,7 +193,7 @@ func TestGetVideo(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			r := bytes.NewReader([]byte("a"))
+			r := io.NopCloser(bytes.NewReader([]byte("a")))
 
 			if testCase.executeGetGameVideo {
 				mockGameVideoService.

--- a/src/service/game_file.go
+++ b/src/service/game_file.go
@@ -12,5 +12,5 @@ import (
 
 type GameFile interface {
 	SaveGameFile(ctx context.Context, reader io.Reader, gameID values.GameID, fileType values.GameFileType, entryPoint values.GameFileEntryPoint) (*domain.GameFile, error)
-	GetGameFile(ctx context.Context, gameID values.GameID, environment *values.LauncherEnvironment) (io.Reader, *domain.GameFile, error)
+	GetGameFile(ctx context.Context, gameID values.GameID, environment *values.LauncherEnvironment) (io.ReadCloser, *domain.GameFile, error)
 }

--- a/src/service/game_image.go
+++ b/src/service/game_image.go
@@ -11,5 +11,5 @@ import (
 
 type GameImage interface {
 	SaveGameImage(ctx context.Context, reader io.Reader, gameID values.GameID) error
-	GetGameImage(ctx context.Context, gameID values.GameID) (io.Reader, error)
+	GetGameImage(ctx context.Context, gameID values.GameID) (io.ReadCloser, error)
 }

--- a/src/service/game_video.go
+++ b/src/service/game_video.go
@@ -11,5 +11,5 @@ import (
 
 type GameVideo interface {
 	SaveGameVideo(ctx context.Context, reader io.Reader, gameID values.GameID) error
-	GetGameVideo(ctx context.Context, gameID values.GameID) (io.Reader, error)
+	GetGameVideo(ctx context.Context, gameID values.GameID) (io.ReadCloser, error)
 }

--- a/src/service/v1/game_file.go
+++ b/src/service/v1/game_file.go
@@ -133,7 +133,7 @@ func (gf *GameFile) SaveGameFile(ctx context.Context, reader io.Reader, gameID v
 	return gameFile, nil
 }
 
-func (gf *GameFile) GetGameFile(ctx context.Context, gameID values.GameID, environment *values.LauncherEnvironment) (io.Reader, *domain.GameFile, error) {
+func (gf *GameFile) GetGameFile(ctx context.Context, gameID values.GameID, environment *values.LauncherEnvironment) (io.ReadCloser, *domain.GameFile, error) {
 	_, err := gf.gameRepository.GetGame(ctx, gameID, repository.LockTypeNone)
 	if errors.Is(err, repository.ErrRecordNotFound) {
 		return nil, nil, service.ErrInvalidGameID

--- a/src/service/v1/game_image.go
+++ b/src/service/v1/game_image.go
@@ -132,7 +132,7 @@ func (gi *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, gameID
 	return nil
 }
 
-func (gi *GameImage) GetGameImage(ctx context.Context, gameID values.GameID) (io.Reader, error) {
+func (gi *GameImage) GetGameImage(ctx context.Context, gameID values.GameID) (io.ReadCloser, error) {
 	_, err := gi.gameRepository.GetGame(ctx, gameID, repository.LockTypeNone)
 	if errors.Is(err, repository.ErrRecordNotFound) {
 		return nil, service.ErrInvalidGameID

--- a/src/service/v1/game_video.go
+++ b/src/service/v1/game_video.go
@@ -128,7 +128,7 @@ func (gv *GameVideo) SaveGameVideo(ctx context.Context, reader io.Reader, gameID
 	return nil
 }
 
-func (gv *GameVideo) GetGameVideo(ctx context.Context, gameID values.GameID) (io.Reader, error) {
+func (gv *GameVideo) GetGameVideo(ctx context.Context, gameID values.GameID) (io.ReadCloser, error) {
 	_, err := gv.gameRepository.GetGame(ctx, gameID, repository.LockTypeNone)
 	if errors.Is(err, repository.ErrRecordNotFound) {
 		return nil, service.ErrInvalidGameID


### PR DESCRIPTION
PipeReaderがCloseされていないため、writeを行うgoroutineが永遠に終わらなくなっていた。
また、これによりファイルダウンロードのセマフォがロックされ続け、ファイルのダウンロードができなくなっていた。

#287 と合わさって、m011のCPU 100%張り付きの原因となっていた可能性が高い。