### PR TITLE
アプリケーション環境からmock削除

### DIFF
--- a/src/config/v1/app.go
+++ b/src/config/v1/app.go
@@ -24,8 +24,6 @@ func (*App) Status() (config.AppStatus, error) {
 		return config.AppStatusProduction, nil
 	case "development":
 		return config.AppStatusDevelopment, nil
-	case "mock":
-		return config.AppStatusDevelopment, nil
 	}
 
 	return 0, errors.New("invalid env")


### PR DESCRIPTION
#323 でmock環境を消したのでいらなくなった。