### PR TITLE
go.modでciのgoのバージョン設定

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,18 +6,15 @@ on:
       - 'main'
   pull_request:
 
-env:
-  GO_VERSION: '1.17'
-
 jobs:
   mod:
     name: Mod
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -30,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [mod]
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
       - run: go generate ./...
       - uses: actions/upload-artifact@v3
         with:
@@ -46,10 +43,10 @@ jobs:
     env:
       GOCACHE: "/tmp/go/cache"
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -77,12 +74,12 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: trap_collection
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
       - uses: actions/download-artifact@v3
         with:
           name: mockGenerated
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -111,12 +108,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [mockgen]
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
       - uses: actions/download-artifact@v3
         with:
           name: mockGenerated
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod


### PR DESCRIPTION
setup-goに追加された、go.modでGoのversionを設定する機能を利用してGitHub ActionsのGoのバージョン指定をするようにした。
ref: https://github.com/actions/setup-go/releases/tag/v3.1.0