### PR TITLE
TestSaveGameVideoを高速化

### DIFF
--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -1,0 +1,51 @@
+package io
+
+import (
+	"fmt"
+	"io"
+)
+
+func ReaderEqual(r1 io.Reader, r2 io.Reader) (bool, error) {
+	buf1 := make([]byte, 1024)
+	buf2 := make([]byte, 1024)
+
+	i := 0
+	isEOF1 := false
+	isEOF2 := false
+	for ; ; i++ {
+		n1, err := r1.Read(buf1)
+		if err != nil {
+			if err == io.EOF {
+				isEOF1 = true
+			} else {
+				return false, fmt.Errorf("failed to read r1: %w", err)
+			}
+		}
+
+		n2, err := r2.Read(buf2)
+		if err != nil {
+			if err == io.EOF {
+				isEOF2 = true
+			} else {
+				return false, fmt.Errorf("failed to read r2: %w", err)
+			}
+		}
+
+		if n1 != n2 {
+			return false, nil
+		}
+
+		for i := 0; i < n1; i++ {
+			if buf1[i] != buf2[i] {
+				return false, nil
+			}
+		}
+
+		if isEOF1 {
+			return isEOF2, nil
+		}
+		if isEOF2 {
+			return false, nil
+		}
+	}
+}

--- a/pkg/io/io_test.go
+++ b/pkg/io/io_test.go
@@ -1,0 +1,76 @@
+package io_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/trap-collection-server/pkg/io"
+)
+
+func TestReaderEqual(t *testing.T) {
+	testCases := []struct {
+		description string
+		s1          string
+		s2          string
+		isEqual     bool
+		isErr       bool
+	}{
+		{
+			description: "s1とs2が同じ",
+			s1:          "abc",
+			s2:          "abc",
+			isEqual:     true,
+		},
+		{
+			description: "s1とs2が異なる",
+			s1:          "abc",
+			s2:          "def",
+			isEqual:     false,
+		},
+		{
+			description: "s1の方が長い",
+			s1:          "abcdef",
+			s2:          "abc",
+			isEqual:     false,
+		},
+		{
+			description: "s2の方が長い",
+			s1:          "abc",
+			s2:          "abcdef",
+			isEqual:     false,
+		},
+		{
+			description: "s1が空文字列",
+			s1:          "",
+			s2:          "abc",
+			isEqual:     false,
+		},
+		{
+			description: "s2が空文字列",
+			s1:          "abc",
+			s2:          "",
+			isEqual:     false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			r1 := strings.NewReader(testCase.s1)
+			r2 := strings.NewReader(testCase.s2)
+
+			isEqual, err := io.ReaderEqual(r1, r2)
+
+			if testCase.isErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil || testCase.isErr {
+				return
+			}
+
+			assert.Equal(t, testCase.isEqual, isEqual)
+		})
+	}
+}

--- a/src/storage/mock/game_video.go
+++ b/src/storage/mock/game_video.go
@@ -1,7 +1,6 @@
 package mock
 
 import (
-	"bytes"
 	context "context"
 	io "io"
 	reflect "reflect"
@@ -16,7 +15,7 @@ import (
 type GameVideo struct {
 	ctrl     *gomock.Controller
 	recorder *GameVideoMockRecorder
-	buf      *bytes.Buffer
+	buf      io.Writer
 }
 
 // GameVideoMockRecorder is the mock recorder for MockGameVideo.
@@ -25,7 +24,7 @@ type GameVideoMockRecorder struct {
 }
 
 // NewGameVideo creates a new mock instance.
-func NewGameVideo(ctrl *gomock.Controller, buf *bytes.Buffer) *GameVideo {
+func NewGameVideo(ctrl *gomock.Controller, buf io.Writer) *GameVideo {
 	mock := &GameVideo{ctrl: ctrl}
 	mock.recorder = &GameVideoMockRecorder{mock}
 	mock.buf = buf


### PR DESCRIPTION
動画ファイルがメモリに載っていたため遅くなっていたのを修正した。
修正前: 1.70s ( https://github.com/traPtitech/trap-collection-server/runs/6427602421?check_suite_focus=true#step:6:2162 )