### PR TITLE
docker関連のrefactoring

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,20 +22,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gomod-
       - run: go mod download
-  mockgen:
-    name: MockGen
-    runs-on: ubuntu-latest
-    needs: [mod]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
-      - run: go generate ./...
-      - uses: actions/upload-artifact@v3
-        with:
-          name: mockGenerated
-          path: ./
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -64,7 +50,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: [mockgen]
     services:
       mysql:
         image: mariadb:10.6.4
@@ -74,9 +59,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: trap_collection
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: mockGenerated
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
@@ -86,6 +69,7 @@ jobs:
           key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
+      - run: go generate ./...
       - run: go test ./src/... -v -coverprofile=./coverage.txt -race -vet=off
         env:
           COLLECTION_ENV: production
@@ -106,11 +90,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    needs: [mockgen]
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: mockGenerated
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
@@ -120,6 +101,7 @@ jobs:
           key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
+      - run: go generate ./...
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .vscode
 mysql/data
+tmp
 **/mock/*
 !src/storage/mock/*
 !src/repository/mock/db.go

--- a/docker/base/compose.yaml
+++ b/docker/base/compose.yaml
@@ -1,0 +1,28 @@
+services:
+  collection-server:
+    build:
+      context: ../..
+    environment:
+      DB_USERNAME: root
+      DB_PASSWORD: pass
+      DB_HOSTNAME: mariadb
+      DB_PORT: 3306
+      DB_DATABASE: trap_collection
+    depends_on:
+      mariadb:
+        condition: service_healthy
+  mariadb:
+    image: mariadb:10.6.4
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: pass
+      MYSQL_DATABASE: trap_collection
+      TZ: Asia/Tokyo
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    expose:
+      - 3306
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "127.0.0.1", "-ppass"]
+      timeout: 5m
+      interval: 1s
+      retries: 1000

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,27 +1,19 @@
-# syntax = docker/dockerfile:1.3.0
+# syntax = docker/dockerfile:1.4.1
 
 FROM golang:1.19.0-alpine AS build
 
-RUN apk --update --no-cache add tzdata && \
+RUN apk --update --no-cache add tzdata git && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   apk del tzdata
 
-ENV DOCKERIZE_VERSION v0.6.1
-
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
-  tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
-  rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
-RUN apk add --update --no-cache git
-
+ENV AIR_VERSION v1.40.4
 RUN --mount=type=cache,target=/root/.cache/go-build \
-  go install github.com/cosmtrek/air@v1.27.3
+  go install github.com/cosmtrek/air@$AIR_VERSION
 
 WORKDIR /go/src/github.com/traPtitech/trap-collection-server
 
 COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/go/pkg/mod/cache \
-  go mod download
+RUN go mod download
 
-ENTRYPOINT ["dockerize", "-wait", "tcp://mariadb:3306", "-timeout", "5m", "air"]
+ENTRYPOINT ["air"]
 CMD ["-c", ".air.toml"]

--- a/docker/dev/compose.yaml
+++ b/docker/dev/compose.yaml
@@ -1,15 +1,14 @@
 services:
   collection-server:
+    extends:
+      file: ../base/compose.yaml
+      service: collection-server
     build:
-      context: ../../
       dockerfile: ./docker/dev/Dockerfile
     restart: always
     volumes:
-      - ./.air.toml:/go/src/github.com/traPtitech/trap-collection-server/.air.toml
-      - ../../src/:/go/src/github.com/traPtitech/trap-collection-server/src
-      - ../../pkg/:/go/src/github.com/traPtitech/trap-collection-server/pkg
-      - ../../main.go:/go/src/github.com/traPtitech/trap-collection-server/main.go
-      - ../../cache/:/go/src/github.com/traPtitech/trap-collection-server/cache
+      - ./.air.toml:/etc/trap-collection/.air.toml
+      - ../../:/go/src/github.com/traPtitech/trap-collection-server/
     environment:
       COLLECTION_ENV: development
       STORAGE: local
@@ -17,21 +16,16 @@ services:
       FILE_PATH: ./cache
       CLIENT_ID:
       CLIENT_SECRET:
-      DB_USERNAME: root
-      DB_PASSWORD: pass
-      DB_HOSTNAME: mariadb
-      DB_PORT: 3306
-      DB_DATABASE: trap_collection
       SESSION_SECRET: secret
       PORT: :3000
+    command:
+      - -c
+      - /etc/trap-collection/.air.toml
     ports: 
       - 3000:3000
   mariadb:
-    image: mariadb:10.6.4
-    environment:
-      MYSQL_ROOT_PASSWORD: pass
-      MYSQL_DATABASE: trap_collection
-      TZ: Asia/Tokyo
-    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    extends:
+      file: ../base/compose.yaml
+      service: mariadb
     volumes:
       - ../../mysql/data:/var/lib/mysql

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,24 +1,12 @@
-# syntax = docker/dockerfile:1.3.0
+# syntax = docker/dockerfile:1.4.1
 
 FROM golang:1.19.0-alpine AS build
 
-RUN apk --update --no-cache add tzdata && \
+RUN apk --update --no-cache add tzdata git build-base && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   apk del tzdata
-
-ENV DOCKERIZE_VERSION v0.6.1
-
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
-  tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
-  rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
-RUN apk add --update --no-cache git build-base
 
 WORKDIR /go/src/github.com/traPtitech/trap-collection-server
 
 COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/go/pkg/mod/cache \
-  go mod download
-
-ENTRYPOINT ["dockerize", "-wait", "tcp://mariadb:3306", "-timeout", "5m"]
-CMD []
+RUN go mod download

--- a/docker/test/compose.yaml
+++ b/docker/test/compose.yaml
@@ -1,26 +1,17 @@
 services:
-  app:
+  collection-server:
+    extends:
+      file: ../base/compose.yaml
+      service: collection-server
     build:
-      context: ../../
       dockerfile: ./docker/test/Dockerfile
     environment:
       COLLECTION_ENV: development
-      DB_USERNAME: root
-      DB_PASSWORD: password
-      DB_HOSTNAME: mariadb
-      DB_PORT: 3306
-      DB_DATABASE: trap_collection
     volumes:
       - ../../:/go/src/github.com/traPtitech/trap-collection-server
     working_dir: /go/src/github.com/traPtitech/trap-collection-server
     command: go test ./src/repository/... -v -cover -race
-    depends_on:
-      - mariadb
   mariadb:
-    image: mariadb:10.6.4
-    restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: trap_collection
-    expose:
-      - "3306"
+    extends:
+      file: ../base/compose.yaml
+      service: mariadb


### PR DESCRIPTION
やりたくなったのでサクッとやってしまった。
主に
- extendでのdb絡みの部分の共通化
- healthcheckによるdockerizeの置き換え
- airのバージョン更新
- GitHub Actionsの`go generate`を必要になる各jobで行うように変更
    - job起動時間とdownload artifactの時間、jobのフローみた感じ、共通化するメリットなさそうなため

Close #380 