### PR TITLE
setup-goのcache対応

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,45 +7,15 @@ on:
   pull_request:
 
 jobs:
-  mod:
-    name: Mod
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-
-      - run: go mod download
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [mod]
-    env:
-      GOCACHE: "/tmp/go/cache"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-
-      - uses: actions/cache@v3
-        with:
-          path: /tmp/go/cache
-          key: ${{ runner.os }}-go-build-${{ github.ref }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-go-build-${{ github.ref }}-
-            ${{ runner.os }}-go-build-
+          cache: true
       - run: go build -o collection
   test:
     name: Test
@@ -63,12 +33,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-
+          cache: true
       - run: go generate ./...
       - run: go test ./src/... -v -coverprofile=./coverage.txt -race -vet=off
         env:
@@ -92,19 +57,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # go generate用に、golangci-lintの前にGoのinstallをする
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-
+          cache: true
       - run: go generate ./...
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2.1
         with:
+          go-version-file: go.mod
           reporter: github-pr-check
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_error: true


### PR DESCRIPTION
自前で色々キャッシュしないで良くなったので、自前のキャッシュ実装を消して書き換えた。