### PR TITLE
productionのDockerfileからキャッシュ削除

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -22,14 +22,12 @@ FROM alpine:3.16.2
 
 WORKDIR /go/src/github.com/traPtitech/trap-collection-server
 
-RUN --mount=type=cache,target=/var/cache/apk \
-  apk --update add tzdata \
+RUN apk --update --no-cache add tzdata \
   && cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
   && apk del tzdata \
   && mkdir -p /usr/share/zoneinfo/Asia \
   && ln -s /etc/localtime /usr/share/zoneinfo/Asia/Tokyo
-RUN --mount=type=cache,target=/var/cache/apk \
-  apk --update add ca-certificates \
+RUN apk --update --no-cache add ca-certificates \
   && update-ca-certificates \
   && apk del ca-certificates
 


### PR DESCRIPTION
GitHub Actionsでのbuildに失敗したので戻す。
複数アーキテクチャのキャッシュが混在したりが怪しい気がしている。