### PR TITLE
storageのGetGameFile,GetGameImage,GetGameVideo削除

### DIFF
--- a/src/storage/local/game_file.go
+++ b/src/storage/local/game_file.go
@@ -80,6 +80,7 @@ func (gf *GameFile) GetGameFile(ctx context.Context, writer io.Writer, file *dom
 }
 
 func (gf *GameFile) GetTempURL(ctx context.Context, file *domain.GameFile, expires time.Duration) (values.GameFileTmpURL, error) {
+	// 正しいURLにはならないが、開発環境用のmockのため妥協する
 	tmpURL, err := url.Parse(fmt.Sprintf("file://%s", path.Join(gf.fileRootPath, uuid.UUID(file.GetID()).String())))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse url: %w", err)

--- a/src/storage/local/game_file.go
+++ b/src/storage/local/game_file.go
@@ -59,26 +59,6 @@ func (gf *GameFile) SaveGameFile(ctx context.Context, reader io.Reader, fileID v
 	return nil
 }
 
-func (gf *GameFile) GetGameFile(ctx context.Context, writer io.Writer, file *domain.GameFile) error {
-	filePath := path.Join(gf.fileRootPath, uuid.UUID(file.GetID()).String())
-
-	f, err := os.Open(filePath)
-	if errors.Is(err, fs.ErrNotExist) {
-		return storage.ErrNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to open file: %w", err)
-	}
-	defer f.Close()
-
-	_, err = io.Copy(writer, f)
-	if err != nil {
-		return fmt.Errorf("failed to copy: %w", err)
-	}
-
-	return nil
-}
-
 func (gf *GameFile) GetTempURL(ctx context.Context, file *domain.GameFile, expires time.Duration) (values.GameFileTmpURL, error) {
 	// 正しいURLにはならないが、開発環境用のmockのため妥協する
 	tmpURL, err := url.Parse(fmt.Sprintf("file://%s", path.Join(gf.fileRootPath, uuid.UUID(file.GetID()).String())))

--- a/src/storage/local/game_file_test.go
+++ b/src/storage/local/game_file_test.go
@@ -8,13 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/traPtitech/trap-collection-server/src/config/mock"
-	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/storage"
 )
@@ -114,115 +112,6 @@ func TestSaveGameFile(t *testing.T) {
 			}
 
 			assert.Equal(t, expectBytes, actualBytes)
-		})
-	}
-}
-
-func TestGetGameFile(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	rootPath := "./get_game_file_test"
-	mockConf := mock.NewMockStorageLocal(ctrl)
-	mockConf.
-		EXPECT().
-		Path().
-		Return(rootPath, nil)
-	directoryManager, err := NewDirectoryManager(mockConf)
-	if err != nil {
-		t.Fatalf("failed to create directory manager: %v", err)
-		return
-	}
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		if err != nil {
-			t.Fatalf("failed to remove directory: %v", err)
-		}
-	}()
-
-	gameFile, err := NewGameFile(directoryManager)
-	if err != nil {
-		t.Fatalf("failed to create game file: %v", err)
-	}
-
-	fileRootPath := filepath.Join(string(rootPath), "files")
-
-	type test struct {
-		description string
-		file        *domain.GameFile
-		isFileExist bool
-		fileContent *bytes.Buffer
-		isErr       bool
-		err         error
-	}
-
-	testCases := []test{
-		{
-			description: "ファイルが存在するので読み込める",
-			file: domain.NewGameFile(
-				values.NewGameFileID(),
-				values.GameFileTypeJar,
-				"/path/to/game.jar",
-				values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
-				time.Now(),
-			),
-			isFileExist: true,
-			fileContent: bytes.NewBufferString("test"),
-		},
-		{
-			description: "ファイルが存在しないので読み込めない",
-			file: domain.NewGameFile(
-				values.NewGameFileID(),
-				values.GameFileTypeJar,
-				"/path/to/game.jar",
-				values.NewGameFileHashFromBytes([]byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73, 0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}),
-				time.Now(),
-			),
-			isErr: true,
-			err:   storage.ErrNotFound,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.description, func(t *testing.T) {
-			var expectBytes []byte
-			if testCase.isFileExist {
-				expectBytes = testCase.fileContent.Bytes()
-
-				func() {
-					f, err := os.Create(filepath.Join(fileRootPath, uuid.UUID(testCase.file.GetID()).String()))
-					if err != nil {
-						t.Fatalf("failed to write file: %v", err)
-					}
-					defer f.Close()
-
-					_, err = io.Copy(f, testCase.fileContent)
-					if err != nil {
-						t.Fatalf("failed to write file: %v", err)
-					}
-				}()
-			}
-
-			buf := bytes.NewBuffer(nil)
-
-			err := gameFile.GetGameFile(ctx, buf, testCase.file)
-
-			if testCase.isErr {
-				if testCase.err == nil {
-					assert.Error(t, err)
-				} else if !errors.Is(err, testCase.err) {
-					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
-				}
-			} else {
-				assert.NoError(t, err)
-			}
-			if err != nil {
-				return
-			}
-
-			assert.Equal(t, expectBytes, buf.Bytes())
 		})
 	}
 }

--- a/src/storage/local/game_image.go
+++ b/src/storage/local/game_image.go
@@ -80,7 +80,8 @@ func (gi *GameImage) GetGameImage(ctx context.Context, writer io.Writer, image *
 }
 
 func (gi *GameImage) GetTempURL(ctx context.Context, image *domain.GameImage, expires time.Duration) (values.GameImageTmpURL, error) {
-	tmpURL, err := url.Parse(fmt.Sprintf("file.//%s", path.Join(gi.imageRootPath, uuid.UUID(image.GetID()).String())))
+	// 正しいURLにはならないが、開発環境用のmockのため妥協する
+	tmpURL, err := url.Parse(fmt.Sprintf("file://%s", path.Join(gi.imageRootPath, uuid.UUID(image.GetID()).String())))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse url: %w", err)
 	}

--- a/src/storage/local/game_image.go
+++ b/src/storage/local/game_image.go
@@ -59,26 +59,6 @@ func (gi *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, imageI
 	return nil
 }
 
-func (gi *GameImage) GetGameImage(ctx context.Context, writer io.Writer, image *domain.GameImage) error {
-	imagePath := path.Join(gi.imageRootPath, uuid.UUID(image.GetID()).String())
-
-	f, err := os.Open(imagePath)
-	if errors.Is(err, fs.ErrNotExist) {
-		return storage.ErrNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to open file: %w", err)
-	}
-	defer f.Close()
-
-	_, err = io.Copy(writer, f)
-	if err != nil {
-		return fmt.Errorf("failed to copy: %w", err)
-	}
-
-	return nil
-}
-
 func (gi *GameImage) GetTempURL(ctx context.Context, image *domain.GameImage, expires time.Duration) (values.GameImageTmpURL, error) {
 	// 正しいURLにはならないが、開発環境用のmockのため妥協する
 	tmpURL, err := url.Parse(fmt.Sprintf("file://%s", path.Join(gi.imageRootPath, uuid.UUID(image.GetID()).String())))

--- a/src/storage/local/game_image_test.go
+++ b/src/storage/local/game_image_test.go
@@ -8,13 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/traPtitech/trap-collection-server/src/config/mock"
-	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/storage"
 )
@@ -114,111 +112,6 @@ func TestSaveGameImage(t *testing.T) {
 			}
 
 			assert.Equal(t, expectBytes, actualBytes)
-		})
-	}
-}
-
-func TestGetGameImage(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	rootPath := "./get_game_image_test"
-	mockConf := mock.NewMockStorageLocal(ctrl)
-	mockConf.
-		EXPECT().
-		Path().
-		Return(rootPath, nil)
-	directoryManager, err := NewDirectoryManager(mockConf)
-	if err != nil {
-		t.Fatalf("failed to create directory manager: %v", err)
-		return
-	}
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		if err != nil {
-			t.Fatalf("failed to remove directory: %v", err)
-		}
-	}()
-
-	gameImage, err := NewGameImage(directoryManager)
-	if err != nil {
-		t.Fatalf("failed to create game image: %v", err)
-	}
-
-	imageRootPath := filepath.Join(string(rootPath), "images")
-
-	type test struct {
-		description string
-		image       *domain.GameImage
-		isFileExist bool
-		fileContent *bytes.Buffer
-		isErr       bool
-		err         error
-	}
-
-	testCases := []test{
-		{
-			description: "ファイルが存在するので読み込める",
-			image: domain.NewGameImage(
-				values.NewGameImageID(),
-				values.GameImageTypeJpeg,
-				time.Now(),
-			),
-			isFileExist: true,
-			fileContent: bytes.NewBufferString("b"),
-		},
-		{
-			description: "ファイルが存在しないので読み込めない",
-			image: domain.NewGameImage(
-				values.NewGameImageID(),
-				values.GameImageTypeJpeg,
-				time.Now(),
-			),
-			isErr: true,
-			err:   storage.ErrNotFound,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.description, func(t *testing.T) {
-			var expectBytes []byte
-			if testCase.isFileExist {
-				expectBytes = testCase.fileContent.Bytes()
-
-				func() {
-					f, err := os.Create(filepath.Join(imageRootPath, uuid.UUID(testCase.image.GetID()).String()))
-					if err != nil {
-						t.Fatalf("failed to write file: %v", err)
-					}
-					defer f.Close()
-
-					_, err = io.Copy(f, testCase.fileContent)
-					if err != nil {
-						t.Fatalf("failed to write file: %v", err)
-					}
-				}()
-			}
-
-			buf := bytes.NewBuffer(nil)
-
-			err := gameImage.GetGameImage(ctx, buf, testCase.image)
-
-			if testCase.isErr {
-				if testCase.err == nil {
-					assert.Error(t, err)
-				} else if !errors.Is(err, testCase.err) {
-					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
-				}
-			} else {
-				assert.NoError(t, err)
-			}
-			if err != nil {
-				return
-			}
-
-			assert.Equal(t, expectBytes, buf.Bytes())
 		})
 	}
 }

--- a/src/storage/local/game_video.go
+++ b/src/storage/local/game_video.go
@@ -59,26 +59,6 @@ func (gv *GameVideo) SaveGameVideo(ctx context.Context, reader io.Reader, videoI
 	return nil
 }
 
-func (gv *GameVideo) GetGameVideo(ctx context.Context, writer io.Writer, video *domain.GameVideo) error {
-	videoPath := path.Join(gv.videoRootPath, uuid.UUID(video.GetID()).String())
-
-	f, err := os.Open(videoPath)
-	if errors.Is(err, fs.ErrNotExist) {
-		return storage.ErrNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to open file: %w", err)
-	}
-	defer f.Close()
-
-	_, err = io.Copy(writer, f)
-	if err != nil {
-		return fmt.Errorf("failed to copy: %w", err)
-	}
-
-	return nil
-}
-
 func (gv *GameVideo) GetTempURL(ctx context.Context, video *domain.GameVideo, expires time.Duration) (values.GameVideoTmpURL, error) {
 	// 正しいURLにはならないが、開発環境用のmockのため妥協する
 	tmpURL, err := url.Parse(fmt.Sprintf("file://%s", path.Join(gv.videoRootPath, uuid.UUID(video.GetID()).String())))

--- a/src/storage/local/game_video.go
+++ b/src/storage/local/game_video.go
@@ -80,6 +80,7 @@ func (gv *GameVideo) GetGameVideo(ctx context.Context, writer io.Writer, video *
 }
 
 func (gv *GameVideo) GetTempURL(ctx context.Context, video *domain.GameVideo, expires time.Duration) (values.GameVideoTmpURL, error) {
+	// 正しいURLにはならないが、開発環境用のmockのため妥協する
 	tmpURL, err := url.Parse(fmt.Sprintf("file://%s", path.Join(gv.videoRootPath, uuid.UUID(video.GetID()).String())))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse url: %w", err)

--- a/src/storage/local/game_video_test.go
+++ b/src/storage/local/game_video_test.go
@@ -9,13 +9,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/traPtitech/trap-collection-server/src/config/mock"
-	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/storage"
 )
@@ -131,133 +129,6 @@ func TestSaveGameVideo(t *testing.T) {
 			}
 
 			assert.Equal(t, expectBytes, actualBytes)
-		})
-	}
-}
-
-func TestGetGameVideo(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	rootPath := "./get_game_video_test"
-	mockConf := mock.NewMockStorageLocal(ctrl)
-	mockConf.
-		EXPECT().
-		Path().
-		Return(rootPath, nil)
-	directoryManager, err := NewDirectoryManager(mockConf)
-	if err != nil {
-		t.Fatalf("failed to create directory manager: %v", err)
-		return
-	}
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		if err != nil {
-			t.Fatalf("failed to remove directory: %v", err)
-		}
-	}()
-
-	gameVideo, err := NewGameVideo(directoryManager)
-	if err != nil {
-		t.Fatalf("failed to create game image: %v", err)
-	}
-
-	videoRootPath := filepath.Join(string(rootPath), "videos")
-
-	type test struct {
-		description string
-		video       *domain.GameVideo
-		isFileExist bool
-		isErr       bool
-		err         error
-	}
-
-	testCases := []test{
-		{
-			description: "ファイルが存在するので読み込める",
-			video: domain.NewGameVideo(
-				values.NewGameVideoID(),
-				values.GameVideoTypeMp4,
-				time.Now(),
-			),
-			isFileExist: true,
-		},
-		{
-			description: "ファイルが存在しないので読み込めない",
-			video: domain.NewGameVideo(
-				values.NewGameVideoID(),
-				values.GameVideoTypeMp4,
-				time.Now(),
-			),
-			isErr: true,
-			err:   storage.ErrNotFound,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.description, func(t *testing.T) {
-			var expectBytes []byte
-			if testCase.isFileExist {
-				videoBuf := bytes.NewBuffer(nil)
-
-				switch testCase.video.GetType() {
-				case values.GameVideoTypeMp4:
-					err := func() error {
-						f, err := os.Open("../../../testdata/1.mp4")
-						if err != nil {
-							return fmt.Errorf("failed to open file: %w", err)
-						}
-						defer f.Close()
-
-						_, err = io.Copy(videoBuf, f)
-						if err != nil {
-							return fmt.Errorf("failed to copy file: %w", err)
-						}
-
-						return nil
-					}()
-					if err != nil {
-						t.Fatalf("failed to encode image: %s", err)
-					}
-				default:
-					t.Fatalf("invalid video type: %v\n", testCase.video.GetType())
-				}
-				expectBytes = videoBuf.Bytes()
-
-				func() {
-					f, err := os.Create(filepath.Join(videoRootPath, uuid.UUID(testCase.video.GetID()).String()))
-					if err != nil {
-						t.Fatalf("failed to write file: %v", err)
-					}
-					defer f.Close()
-
-					_, err = io.Copy(f, videoBuf)
-					if err != nil {
-						t.Fatalf("failed to write file: %v", err)
-					}
-				}()
-			}
-
-			buf := bytes.NewBuffer(nil)
-
-			err := gameVideo.GetGameVideo(ctx, buf, testCase.video)
-
-			if testCase.isErr {
-				if testCase.err == nil {
-					assert.Error(t, err)
-				} else if !errors.Is(err, testCase.err) {
-					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
-				}
-			} else {
-				assert.NoError(t, err)
-			}
-			if err != nil {
-				return
-			}
-
-			assert.Equal(t, expectBytes, buf.Bytes())
 		})
 	}
 }

--- a/src/storage/swift/client.go
+++ b/src/storage/swift/client.go
@@ -145,30 +145,6 @@ var (
 	ErrNotFound = fmt.Errorf("not found")
 )
 
-func (c *Client) loadFile(ctx context.Context, name string, w io.Writer) error {
-	_, _, err := c.connection.Object(ctx, c.containerName, name)
-	if errors.Is(err, swift.ObjectNotFound) {
-		return ErrNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to get object: %w", err)
-	}
-
-	_, err = c.connection.ObjectGet(
-		ctx,
-		c.containerName,
-		name,
-		w,
-		true,
-		nil,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to get object: %w", err)
-	}
-
-	return nil
-}
-
 func (c *Client) createTempURL(ctx context.Context, name string, expires time.Duration) (*url.URL, error) {
 	_, _, err := c.connection.Object(ctx, c.containerName, name)
 	if errors.Is(err, swift.ObjectNotFound) {

--- a/src/storage/swift/client_test.go
+++ b/src/storage/swift/client_test.go
@@ -286,3 +286,27 @@ func TestLoadFile(t *testing.T) {
 		})
 	}
 }
+
+func (c *Client) loadFile(ctx context.Context, name string, w io.Writer) error {
+	_, _, err := c.connection.Object(ctx, c.containerName, name)
+	if errors.Is(err, swift.ObjectNotFound) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get object: %w", err)
+	}
+
+	_, err = c.connection.ObjectGet(
+		ctx,
+		c.containerName,
+		name,
+		w,
+		true,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get object: %w", err)
+	}
+
+	return nil
+}

--- a/src/storage/swift/client_test.go
+++ b/src/storage/swift/client_test.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/ncw/swift/v2"
@@ -198,7 +201,7 @@ func TestSaveFile(t *testing.T) {
 	}
 }
 
-func TestLoadFile(t *testing.T) {
+func TestCreateTempURL(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 
@@ -267,7 +270,7 @@ func TestLoadFile(t *testing.T) {
 
 			buf := bytes.NewBuffer(nil)
 
-			err := client.loadFile(ctx, testCase.name, buf)
+			tmpURL, err := client.createTempURL(ctx, testCase.name, time.Second)
 
 			if testCase.isErr {
 				if testCase.err == nil {
@@ -280,6 +283,16 @@ func TestLoadFile(t *testing.T) {
 			}
 			if err != nil {
 				return
+			}
+
+			res, err := http.Get((*url.URL)(tmpURL).String())
+			if err != nil {
+				t.Fatalf("failed to get file: %v", err)
+			}
+
+			_, err = buf.ReadFrom(res.Body)
+			if err != nil {
+				t.Fatalf("failed to read file: %v", err)
 			}
 
 			assert.Equal(t, expectBytes, buf.Bytes())

--- a/src/storage/swift/game_file.go
+++ b/src/storage/swift/game_file.go
@@ -45,24 +45,6 @@ func (gf *GameFile) SaveGameFile(ctx context.Context, reader io.Reader, fileID v
 	return nil
 }
 
-func (gf *GameFile) GetGameFile(ctx context.Context, writer io.Writer, file *domain.GameFile) error {
-	fileKey := gf.fileKey(file.GetID())
-
-	err := gf.client.loadFile(
-		ctx,
-		fileKey,
-		writer,
-	)
-	if errors.Is(err, ErrNotFound) {
-		return storage.ErrNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to get file: %w", err)
-	}
-
-	return nil
-}
-
 func (gf *GameFile) GetTempURL(ctx context.Context, file *domain.GameFile, expires time.Duration) (values.GameFileTmpURL, error) {
 	fileKey := gf.fileKey(file.GetID())
 

--- a/src/storage/swift/game_image.go
+++ b/src/storage/swift/game_image.go
@@ -43,24 +43,6 @@ func (gi *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, imageI
 	return nil
 }
 
-func (gi *GameImage) GetGameImage(ctx context.Context, writer io.Writer, image *domain.GameImage) error {
-	imageKey := gi.imageKey(image.GetID())
-
-	err := gi.client.loadFile(
-		ctx,
-		imageKey,
-		writer,
-	)
-	if errors.Is(err, ErrNotFound) {
-		return storage.ErrNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to get image: %w", err)
-	}
-
-	return nil
-}
-
 func (gi *GameImage) GetTempURL(ctx context.Context, image *domain.GameImage, expires time.Duration) (values.GameImageTmpURL, error) {
 	filekey := gi.imageKey(image.GetID())
 

--- a/src/storage/swift/game_video.go
+++ b/src/storage/swift/game_video.go
@@ -43,24 +43,6 @@ func (gv *GameVideo) SaveGameVideo(ctx context.Context, reader io.Reader, videoI
 	return nil
 }
 
-func (gv *GameVideo) GetGameVideo(ctx context.Context, writer io.Writer, video *domain.GameVideo) error {
-	videoKey := gv.videoKey(video.GetID())
-
-	err := gv.client.loadFile(
-		ctx,
-		videoKey,
-		writer,
-	)
-	if errors.Is(err, ErrNotFound) {
-		return storage.ErrNotFound
-	}
-	if err != nil {
-		return fmt.Errorf("failed to get video: %w", err)
-	}
-
-	return nil
-}
-
 func (gv *GameVideo) GetTempURL(ctx context.Context, video *domain.GameVideo, expires time.Duration) (values.GameVideoTmpURL, error) {
 	fileKey := gv.videoKey(video.GetID())
 


### PR DESCRIPTION
storageのGetGameFile,GetGameImage,GetGameVideoが全てredirectに置き換えられておりいらないので削除した。
これに伴い、swift packageのloadFileがTestでしか使わなくなったので、`client_test.go`へ移動した。
また、Unit Testが存在しなかったGetTempURLのUnit TestがほぼGetGameFile,GetGameImage,GetGameVideoのテストの流用で実現できたので、書き換えて流用した。