### PR TITLE
API v2

### DIFF
--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -32,9 +32,6 @@ tags:
   - name: gameFile
     description: |
       ゲームのファイル関連のAPIです。
-  - name: gameURL
-    description: |
-      ゲームのURL関連のAPIです。
   - name: gameImage
     description: |
       ゲームの画像関連のAPIです。

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -654,7 +654,7 @@ paths:
       summary: ゲームファイルの作成
       description: |
         指定したゲームIDのゲームにファイルを作成します。
-        作成したゲームファイルは、ゲームのバージョンに紐付けられます。
+        作成したゲームファイルは、1日以内にゲームバージョンと紐づけられない場合自動で削除されます。
   /games/files/{gameFileID}:
     parameters:
       - $ref: '#/components/parameters/gameFileIDInPath'
@@ -703,11 +703,12 @@ paths:
         - gameFile
       security:
         - TrapMemberAuth: []
+        - LauncherGameFileAuth: []
       operationId: getGameFileMeta
       responses:
         "200":
           content:
-            application/octet-stream:
+            application/json:
               schema:
                 $ref: '#/components/schemas/GameFile'
           description: |
@@ -734,6 +735,131 @@ paths:
       summary: ゲームファイルのメタ情報の取得
       description: |
         指定したゲームファイルIDのゲームファイルを取得します。
+
+  # gameImage
+  /games/images:
+    post:
+      tags:
+        - gameImage
+      security:
+        - TrapMemberAuth: []
+      operationId: postGameImage
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/NewGameImage'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameImage'
+          description: |
+            ゲーム画像の作成に成功した際に返されます。
+            レスポンスで作成したゲーム画像のメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲーム画像の作成
+      description: |
+        指定したゲームIDのゲームに画像を作成します。
+        作成したゲーム画像は、1日以内にゲームバージョンと紐づけられない場合に自動で削除されます。
+  /games/images/{gameImageID}:
+    parameters:
+      - $ref: '#/components/parameters/gameImageIDInPath'
+    get:
+      tags:
+        - gameImage
+      security:
+        - TrapMemberAuth: []
+        - LauncherGameImageAuth: []
+      operationId: getGameImage
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/GameImageContent'
+          description: |
+            ゲーム画像の取得に成功した際に返されます。
+            レスポンスで取得したゲーム画像のバイナリが返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            画像IDが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲーム画像が存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲーム画像のバイナリの取得
+      description: |
+        指定したゲーム画像IDのゲーム画像を取得します。
+  /games/images/{gameImageID}/meta:
+    parameters:
+      - $ref: '#/components/parameters/gameImageIDInPath'
+    get:
+      tags:
+        - gameImage
+      security:
+        - TrapMemberAuth: []
+        - LauncherGameImageAuth: []
+      operationId: getGameImageMeta
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameImage'
+          description: |
+            ゲーム画像のメタ情報の取得に成功した際に返されます。
+            レスポンスで取得したゲーム画像のメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            画像IDが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲーム画像が存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲーム画像のメタ情報の取得
+      description: |
+        指定したゲーム画像IDのゲーム画像のメタ情報を取得します。
 
 components:
   responses:
@@ -854,8 +980,7 @@ components:
       in: path
       required: true
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/GameID'
       description: |
         ゲームのIDを示すパスパラメータです。
     gameFileIDInPath:
@@ -863,10 +988,17 @@ components:
       in: path
       required: true
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/GameFileID'
       description: |
         ゲームのファイルのIDを示すパスパラメータです。
+    gameImageIDInPath:
+      name: gameImageID
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/GameImageID'
+      description: |
+        ゲームの画像のIDを示すパスパラメータです。
     productKeyIDInPath:
       name: productKeyID
       in: path
@@ -1167,6 +1299,35 @@ components:
       description: |
         ゲームのファイルのメタ情報です。
 
+    # ゲーム画像
+    NewGameImage:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GameImageType'
+        content:
+          $ref: '#/components/schemas/GameImageContent'
+      required:
+        - type
+        - content
+      description: |
+        ゲームの画像を新しく作成する際に必要な情報です。
+    GameImage:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/GameImageID'
+        type:
+          $ref: '#/components/schemas/GameImageType'
+        createdAt:
+          $ref: '#/components/schemas/GameImageCreatedAt'
+      required:
+        - id
+        - type
+        - createdAt
+      description: |
+        ゲームの画像のメタ情報です。
+
     # 値オブジェクト
     # ユーザー
     UserID:
@@ -1279,7 +1440,6 @@ components:
       format: date-time
       description: |
         ゲームファイルが作成された時刻です。
-        サーバーでの未使用ゲームファイルの削除にのみ使用されます。
 
     # ゲームURL
     GameURL:
@@ -1312,7 +1472,6 @@ components:
       format: date-time
       description: |
         ゲーム画像の作成時刻です。
-        サーバーでの未使用画像の削除にのみ使用されます。
 
     # ゲーム紹介動画
     GameVideoID:
@@ -1336,4 +1495,3 @@ components:
       format: date-time
       description: |
         ゲーム紹介動画の作成時刻です。
-        サーバーでの未使用動画の削除にのみ使用されます。

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -1200,6 +1200,221 @@ paths:
       description: |
         ランチャーのバージョンに紐づくゲームの一覧を取得します。
 
+  # launcherAuth
+  /launchers/{launcherVersionID}/keys:
+    parameters:
+      - $ref: '#/components/parameters/launcherVersionIDInPath'
+    post:
+      tags:
+        - launcherAuth
+      security:
+        - AdminAuth: []
+      parameters:
+        - $ref: '#/components/parameters/productKeyNumInQuery'
+      operationId: postProductKey
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductKey'
+          description: |
+            ランチャーのプロダクトキーの発行に成功した際に返されます。
+            レスポンスで発行したランチャーのプロダクトキーのリストが返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "403":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのプロダクトキーの生成
+      description: |
+        ランチャーのバージョンに対するプロダクトキーを生成します。
+    get:
+      tags:
+        - launcherAuth
+      security:
+        - AdminAuth: []
+      parameters:
+        - $ref: '#/components/parameters/productKeyStatusInQuery'
+      operationId: getProductKeys
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductKey'
+          description: |
+            ランチャーのバージョンに紐づくプロダクトキーの取得に成功した際に返されます。
+            レスポンスで取得したプロダクトキーのリストが返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "403":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのプロダクトキーの一覧の取得
+      description: |
+        ランチャーのバージョンに対するプロダクトキーの一覧を取得します。
+  /launchers/{launcherVersionID}/keys/{productKeyID}/activate:
+    parameters:
+      - $ref: '#/components/parameters/launcherVersionIDInPath'
+      - $ref: '#/components/parameters/productKeyIDInPath'
+    post:
+      tags:
+        - launcherAuth
+      security:
+        - AdminAuth: []
+      operationId: postActivateProductKey
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductKey'
+          description: |
+            プロダクトキーの再有効化に成功した際に返されます。
+            変更後のプロダクトキーの情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "403":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのプロダクトキーが存在しない、または既に有効な場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのプロダクトキーの再有効化
+      description: |
+        ランチャーのバージョンに対するプロダクトキーを再有効化します。
+  /launchers/{launcherVersionID}/keys/{productKeyID}/revoke:
+    parameters:
+      - $ref: '#/components/parameters/launcherVersionIDInPath'
+      - $ref: '#/components/parameters/productKeyIDInPath'
+    post:
+      tags:
+        - launcherAuth
+      security:
+        - AdminAuth: []
+      operationId: postRevokeProductKey
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductKey'
+          description: |
+            プロダクトキーの失効に成功した際に返されます。
+            変更後のプロダクトキーの情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "403":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのプロダクトキーが存在しない、または既に失効している場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのプロダクトキーの失効
+      description: |
+        ランチャーのバージョンに対するプロダクトキーを失効(revoke)します。
+  /launchers/authorize:
+    post:
+      tags:
+        - launcherAuth
+      operationId: postLauncherAuthorize
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LauncherAuthorizeRequest'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LauncherAccessToken'
+          description: |
+            ランチャーの認可に成功した際に返されます。
+            ランチャーのBearer認証に使用するトークンが返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーの認可リクエスト
+      description: |
+        ランチャーの認可リクエストを行います。
+        リクエストに成功すると、ランチャーのアクセストークンが返されます。
+        このアクセストークンを用いたBearer認証で、ランチャー用APIを利用することができます。
+  /launchers/info:
+    get:
+      tags:
+        - launcherAuth
+      operationId: getLauncherInfo
+      security:
+        - LauncherAuth: []
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LauncherVersion'
+          description: 成功
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "403":
+          $ref: '#/components/responses/LauncherForbidden'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのバージョン情報の取得
+      description: |
+        アクセストークンをもとにランチャーのバージョン情報を取得します。
+
 components:
   responses:
     TraPUnauthorized:
@@ -1210,6 +1425,14 @@ components:
       description: |
         traQのOAuth 2.0での認証がされていない、
         もしくは認証したが既にセッションが切れている場合に返されます。
+    LauncherForbidden:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        Bearer認証のアクセストークンが誤っている、
+        もしくは既に有効期限が切れている場合に返されます。
     InternalServerError:
       content:
         application/json:
@@ -1313,6 +1536,25 @@ components:
         $ref: '#/components/schemas/OperatingSystem'
       description: |
         OSの種類を示すクエリパラメータです。
+    productKeyNumInQuery:
+      name: num
+      in: query
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+      description: |
+        生成するプロダクトキーの数を示すクエリパラメータです。
+    productKeyStatusInQuery:
+      name: status
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/ProductKeyStatus'
+      description: |
+        プロダクトキーのステータスを示すクエリパラメータです。
+        指定がない場合は全てのステータスのプロダクトキーが返されます。
     launcherVersionIDInPath:
       name: launcherVersionID
       in: path
@@ -1459,6 +1701,15 @@ components:
       description: |
         ランチャーのバージョンに紐づけられた
         ゲームとバージョンの情報です。
+    LauncherAuthorizeRequest:
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/ProductKeyValue'
+      required:
+        - key
+      description: |
+        ランチャーの認可のリクエストです。
 
     # エンティティ
     # ユーザー
@@ -1805,6 +2056,31 @@ components:
         ランチャーのバージョンです。
         questionnaireは工大祭などのアンケートが必要な際のみ存在します。
 
+    # ランチャーの認証
+    ProductKey:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/ProductKeyID'
+        key:
+          $ref: '#/components/schemas/ProductKeyValue'
+        status:
+          $ref: '#/components/schemas/ProductKeyStatus'
+      required:
+        - id
+        - key
+        - status
+    LauncherAccessToken:
+      type: object
+      properties:
+        accessToken:
+          $ref: '#/components/schemas/LauncherAccessTokenValue'
+        expiresAt:
+          $ref: '#/components/schemas/LauncherAccessTokenExpiresAt'
+      required:
+        - accessToken
+        - expiresAt
+
     # 値オブジェクト
     # ユーザー
     UserID:
@@ -1994,3 +2270,36 @@ components:
       format: date-time
       description: |
         ランチャーのバージョンが作成された時刻です。
+
+    # ランチャーの認証
+    ProductKeyID:
+      type: string
+      format: uuid
+      description: |
+        ランチャーのプロダクトキーのIDです。
+    ProductKeyValue:
+      type: string
+      pattern: '^[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}'
+      example: 12345-ABCDE-67890-FGHIJ-KLMNO
+      description: |
+        ランチャーのプロダクトキーの値です。
+        暗号的にランダムな英数字5文字をハイフン区切りで5つ並べたものです。
+    ProductKeyStatus:
+      type: string
+      enum:
+        - active
+        - revoked
+    LauncherAccessTokenValue:
+      type: string
+      maxLength: 36
+      minLength: 36
+      pattern: '[0-9a-zA-Z]{36}'
+      example: 1234567890abcdef1234567890abcdef1234
+      description: |
+        ランチャーのアクセストークンです。
+        暗号的にランダムな英数字36文字です。
+    LauncherAccessTokenExpiresAt:
+      type: string
+      format: date-time
+      description: |
+        ランチャーのアクセストークンの有効期限です。

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -320,7 +320,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Game'
+                $ref: '#/components/schemas/GameInfo'
           description: |
             ゲームの情報の修正に成功した際に返されます。
             レスポンスで修正後のゲームの情報が返されます。
@@ -397,10 +397,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GameRole'
+                $ref: '#/components/schemas/Game'
           description: |
             ゲームの管理権限の変更に成功した際に返されます。
-            レスポンスで変更後のowner、maintainerの一覧が返されます。
+            レスポンスで変更後のowner、maintainerを含むゲーム情報が返されます。
         "400":
           content:
             application/json:
@@ -456,6 +456,7 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             ゲームID、またはリクエストが不正である場合に返されます。
+            ゲームファイルの種類とwindows,darwin,jarの対応が誤っている場合もこのエラーとなります。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
         "404":
@@ -1164,6 +1165,7 @@ paths:
         - launcherVersion
       security:
         - TrapMemberAuth: []
+        - LauncherIDAuth: []
       operationId: getLauncherVersionGames
       responses:
         "200":
@@ -1254,6 +1256,14 @@ components:
         ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
         アクセストークンが正しく、有効期限が切れていない場合にのみアクセスできます。
         プロダクトキーがrevokeされた場合、即座に反映されます。
+    LauncherIDAuth:
+      type: http
+      scheme: bearer
+      description: |
+        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        アクセストークンが正しく、有効期限が切れていないかつ、
+        launcherIDを対応するランチャーが一致する場合にのみアクセスできます。
+        プロダクトキーがrevokeされた場合、即座に反映されます。
     LauncherGameAuth:
       type: http
       scheme: bearer
@@ -1296,7 +1306,7 @@ components:
       description: |
         OAuth 2.0のAuthorization Codeです。
     operatingSystemInQuery:
-      name: operatingSystem
+      name: os
       in: query
       required: true
       schema:
@@ -1397,7 +1407,7 @@ components:
         games:
           type: array
           items:
-            $ref: '#/components/schemas/Game'
+            $ref: '#/components/schemas/GameInfo'
           description: |
             limit、offsetが適用された後のゲームの一覧です。
       required:
@@ -1443,7 +1453,7 @@ components:
         - type: object
           properties:
             version:
-              $ref: '#/components/schemas/GameVersionInfo'
+              $ref: '#/components/schemas/GameVersion'
           required:
             - version
       description: |
@@ -1597,11 +1607,7 @@ components:
         url:
           $ref: '#/components/schemas/GameURL'
         files:
-          type: array
-          minLength: 1
-          maxLength: 3
-          items:
-            $ref: '#/components/schemas/GameFileID'
+          $ref: '#/components/schemas/GameVersionFiles'
         imageID:
           $ref: '#/components/schemas/GameImageID'
         videoID:
@@ -1626,11 +1632,7 @@ components:
         url:
           $ref: '#/components/schemas/GameURL'
         files:
-          type: array
-          minLength: 1
-          maxLength: 3
-          items:
-            $ref: '#/components/schemas/GameFileID'
+          $ref: '#/components/schemas/GameVersionFiles'
         imageID:
           $ref: '#/components/schemas/GameImageID'
         videoID:
@@ -1647,30 +1649,17 @@ components:
       description: |
         ゲームのバージョンです。
         url、filesはゲームの種類に応じていずれかが存在します。
-    GameVersionInfo:
+    GameVersionFiles:
       type: object
       properties:
-        id:
-          $ref: '#/components/schemas/GameVersionID'
-        name:
-          $ref: '#/components/schemas/GameVersionName'
-        description:
-          $ref: '#/components/schemas/GameVersionDescription'
-        imageID:
-          $ref: '#/components/schemas/GameImageID'
-        videoID:
-          $ref: '#/components/schemas/GameVideoID'
-        createdAt:
-          $ref: '#/components/schemas/GameVersionCreatedAt'
-      required:
-        - id
-        - name
-        - description
-        - imageID
-        - videoID
-        - createdAt
+        win32:
+          $ref: '#/components/schemas/GameFileID'
+        darwin:
+          $ref: '#/components/schemas/GameFileID'
+        jar:
+          $ref: '#/components/schemas/GameFileID'
       description: |
-        ゲームのバージョンについての情報です。
+        ゲームバージョンに紐づいたファイルの情報です。
 
     # ゲームファイル
     NewGameFile:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -21,7 +21,7 @@ tags:
   - name: gameURL
   - name: gameImage
   - name: gameVideo
-  - name: version
+  - name: launcherVersion
   - name: launcherAuth
   - name: seat
 

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -222,17 +222,39 @@ paths:
       description: |
         traP Collection全体の管理者を追加します。
         このAPIは管理者のみが利用できます。
+    get:
+      tags:
+        - admin
+      security:
+        - TrapMemberAuth: []
+      operationId: getAdmins
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+          description: |
+            traP Collection全体の管理者一覧の取得に成功した際に返されます。
+            レスポンスでtraP Collection全体の管理者の一覧が返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: traPの管理者一覧取得
+      description: |
+        traP Collection全体の管理者の一覧を取得します。
+  /admins/{userID}:
+    parameters:
+      - $ref: '#/components/parameters/userIDInPath'
     delete:
       tags:
         - admin
       security:
         - AdminAuth: []
       operationId: deleteAdmin
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UserRequest'
       responses:
         "200":
           content:
@@ -260,30 +282,6 @@ paths:
       description: |
         traP Collection全体の管理者を削除します。
         このAPIは管理者のみが利用できます。
-    get:
-      tags:
-        - admin
-      security:
-        - TrapMemberAuth: []
-      operationId: getAdmins
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/User'
-          description: |
-            traP Collection全体の管理者一覧の取得に成功した際に返されます。
-            レスポンスでtraP Collection全体の管理者の一覧が返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
-        "500":
-          $ref: '#/components/responses/InternalServerError'
-      summary: traPの管理者一覧取得
-      description: |
-        traP Collection全体の管理者の一覧を取得します。
 
   # game
   /games:
@@ -2038,6 +2036,14 @@ components:
       description: |
         プロダクトキーのステータスを示すクエリパラメータです。
         指定がない場合は全てのステータスのプロダクトキーが返されます。
+    userIDInPath:
+      name: userID
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/UserID'
+      description: |
+        ユーザーIDを示すパスパラメータです。
     editionIDInPath:
       name: editionID
       in: path

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -1528,14 +1528,6 @@ components:
         type: string
       description: |
         OAuth 2.0のAuthorization Codeです。
-    operatingSystemInQuery:
-      name: os
-      in: query
-      required: true
-      schema:
-        $ref: '#/components/schemas/OperatingSystem'
-      description: |
-        OSの種類を示すクエリパラメータです。
     productKeyNumInQuery:
       name: num
       in: query
@@ -1622,11 +1614,6 @@ components:
           example: Internal Server Error
       required:
         - message
-    OperatingSystem:
-      type: string
-      enum:
-        - win32
-        - darwin
     PostGameResponse:
       type: object
       allOf:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -303,7 +303,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostGameResponse'
+                $ref: '#/components/schemas/Game'
           description: |
             ゲームの追加に成功した際に返されます。
             レスポンスで新しく追加されたゲームの情報が返されます。
@@ -1988,18 +1988,6 @@ components:
         - id
       description: |
         ユーザーを指定するリクエストです。
-    PostGameResponse:
-      type: object
-      allOf:
-        - $ref: '#/components/schemas/Game'
-        - type: object
-          properties:
-            version:
-              $ref: '#/components/schemas/GameVersion'
-          required:
-            - latestVersion
-          description: |
-            ゲームと追加されたバージョンの情報です。
     GetGamesResponse:
       type: object
       properties:
@@ -2145,12 +2133,9 @@ components:
             指定されない場合、空配列として扱われます。
             ゲームの作成を実行したユーザーを含むownerと重複するユーザーが存在した場合、
             400エラーとなります。
-        version:
-          $ref: '#/components/schemas/NewGameVersion'
       required:
         - name
         - description
-        - version
       description: |
         ゲームを新しく作成する際に必要な情報です。
     PatchGame:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -2216,30 +2216,6 @@ components:
       description: |
         ゲームの情報です。
 
-    # ゲーム管理権限
-    GameRole:
-      type: object
-      properties:
-        owners:
-          type: array
-          minLength: 1
-          items:
-            $ref: '#/components/schemas/UserID'
-          description: |
-            ゲームのownerの一覧です。
-        maintainers:
-          type: array
-          minLength: 1
-          items:
-            $ref: '#/components/schemas/UserID'
-          description: |
-            ゲームのmaintainerの一覧です。
-            maintainerがいない場合、このフィールドは存在しません。
-      required:
-        - owners
-      description: |
-        ゲームのownerとmaintainerの一覧です。
-
     # ゲームバージョン
     NewGameVersion:
       type: object

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -648,7 +648,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: |
-            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+            指定したIDのゲームファイルが存在しない、または削除されている場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: ゲームファイルの作成
@@ -773,7 +773,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: |
-            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+            指定したIDのゲーム画像が存在しない、または削除されている場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: ゲーム画像の作成
@@ -860,6 +860,131 @@ paths:
       summary: ゲーム画像のメタ情報の取得
       description: |
         指定したゲーム画像IDのゲーム画像のメタ情報を取得します。
+
+  # gameVideo
+  /games/videos:
+    post:
+      tags:
+        - gameVideo
+      security:
+        - TrapMemberAuth: []
+      operationId: postGameVideo
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/NewGameVideo'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameVideo'
+          description: |
+            ゲーム動画の作成に成功した際に返されます。
+            レスポンスで作成したゲーム動画のメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲーム動画が存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲーム動画の作成
+      description: |
+        指定したゲームIDのゲームに動画を作成します。
+        作成したゲーム動画は、1日以内にゲームバージョンと紐づけられない場合に自動で削除されます。
+  /games/videos/{gameVideoID}:
+    parameters:
+      - $ref: '#/components/parameters/gameVideoIDInPath'
+    get:
+      tags:
+        - gameVideo
+      security:
+        - TrapMemberAuth: []
+        - LauncherGameVideoAuth: []
+      operationId: getGameVideo
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/GameVideoContent'
+          description: |
+            ゲーム動画の取得に成功した際に返されます。
+            レスポンスで取得したゲーム動画のバイナリが返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            動画IDが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲーム動画が存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲーム動画のバイナリの取得
+      description: |
+        指定したゲーム動画IDのゲーム動画を取得します。
+  /games/videos/{gameVideoID}/meta:
+    parameters:
+      - $ref: '#/components/parameters/gameVideoIDInPath'
+    get:
+      tags:
+        - gameVideo
+      security:
+        - TrapMemberAuth: []
+        - LauncherGameVideoAuth: []
+      operationId: getGameVideoMeta
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameVideo'
+          description: |
+            ゲーム動画のメタ情報の取得に成功した際に返されます。
+            レスポンスで取得したゲーム動画のメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            動画IDが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲーム動画が存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲーム動画のメタ情報の取得
+      description: |
+        指定したゲーム動画IDのゲーム動画のメタ情報を取得します。
 
 components:
   responses:
@@ -999,6 +1124,14 @@ components:
         $ref: '#/components/schemas/GameImageID'
       description: |
         ゲームの画像のIDを示すパスパラメータです。
+    gameVideoIDInPath:
+      name: gameVideoID
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/GameVideoID'
+      description: |
+        ゲームの動画のIDを示すパスパラメータです。
     productKeyIDInPath:
       name: productKeyID
       in: path
@@ -1327,6 +1460,35 @@ components:
         - createdAt
       description: |
         ゲームの画像のメタ情報です。
+
+    # ゲーム動画
+    NewGameVideo:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GameVideoType'
+        content:
+          $ref: '#/components/schemas/GameVideoContent'
+      required:
+        - type
+        - content
+      description: |
+        ゲームの動画を新しく作成する際に必要な情報です。
+    GameVideo:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/GameVideoID'
+        type:
+          $ref: '#/components/schemas/GameVideoType'
+        createdAt:
+          $ref: '#/components/schemas/GameVideoCreatedAt'
+      required:
+        - id
+        - type
+        - createdAt
+      description: |
+        ゲームの動画のメタ情報です。
 
     # 値オブジェクト
     # ユーザー

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -203,7 +203,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GameWithLatestVersion'
+                $ref: '#/components/schemas/PostGameResponse'
           description: |
             ゲームの追加に成功した際に返されます。
             レスポンスで新しく追加されたゲームの情報が返されます。
@@ -689,6 +689,18 @@ components:
       enum:
         - win32
         - darwin
+    PostGameResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Game'
+        - type: object
+          properties:
+            version:
+              $ref: '#/components/schemas/GameVersion'
+          required:
+            - latestVersion
+          description: |
+            ゲームと追加されたバージョンの情報です。
     GetGamesResponse:
       type: object
       properties:
@@ -821,19 +833,6 @@ components:
         - createdAt
       description: |
         ゲームの情報です。
-    GameWithLatestVersion:
-      type: object
-      allOf:
-        - $ref: '#/components/schemas/Game'
-        - type: object
-          properties:
-            latestVersion:
-              $ref: '#/components/schemas/GameVersion'
-          required:
-            - latestVersion
-          description: |
-            ゲームとその最新バージョンの情報です。
-            ゲームの作成時のレスポンスのみで使用します。
 
     # ゲーム管理権限
     GameRole:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -1577,6 +1577,108 @@ paths:
       description: |
         アクセストークンをもとにランチャーのバージョン情報を取得します。
 
+  #seat
+  /seats:
+    post:
+      tags:
+        - seat
+      operationId: postSeat
+      security:
+        - TrapMemberAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostSeatRequest'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Seat'
+          description: |
+            席数の変更に成功した際に返されます。
+            変更後の席一覧が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: 席数の変更
+      description: |
+        席数を変更します。
+    get:
+      tags:
+        - seat
+      operationId: getSeats
+      security:
+        - TrapMemberAuth: []
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Seat'
+          description: |
+            座席一覧の取得に成功した際に返されます。
+            座席一覧が返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: 座席一覧の取得
+      description: |
+        座席一覧を取得します。
+  /seats/{seatID}:
+    parameters:
+      - $ref: '#/components/parameters/seatIDInPath'
+    patch:
+      tags:
+        - seat
+      operationId: patchSeatStatus
+      security:
+        - TrapMemberAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchSeatStatusRequest'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Seat'
+          description: |
+            席の変更に成功した際に返されます。
+            変更後の席情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: 席の変更
+      description: |
+        席の変更を行います。
+
 components:
   responses:
     TraPUnauthorized:
@@ -1771,7 +1873,7 @@ components:
       in: path
       required: true
       schema:
-        type: integer
+        $ref: '#/components/schemas/SeatID'
       description: |
         席のIDを示すパスパラメータです。
   schemas:
@@ -1866,6 +1968,27 @@ components:
         - key
       description: |
         ランチャーの認可のリクエストです。
+    PostSeatRequest:
+      type: object
+      properties:
+        num:
+          type: integer
+          minimum: 1
+          description: |
+            席数です。
+      required:
+        - num
+      description: |
+        席数を変更するためのリクエストです。
+    PatchSeatStatusRequest:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/SeatStatus'
+      required:
+        - status
+      description: |
+        席の着席状態を変更するためのリクエストです。
 
     # エンティティ
     # ユーザー
@@ -2237,6 +2360,20 @@ components:
         - accessToken
         - expiresAt
 
+    # 席
+    Seat:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/SeatID'
+        status:
+          $ref: '#/components/schemas/SeatStatus'
+      required:
+        - id
+        - status
+      description: |
+        席の情報です。
+
     # 値オブジェクト
     # ユーザー
     UserID:
@@ -2459,3 +2596,18 @@ components:
       format: date-time
       description: |
         ランチャーのアクセストークンの有効期限です。
+
+    # 席
+    SeatID:
+      type: integer
+      minimum: 1
+      description: |
+        席のIDです。
+    SeatStatus:
+      type: string
+      enum:
+        - in-use
+        - empty
+      description: |
+        席の状態です。
+        in-useは使用中、emptyは空席です。

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -944,7 +944,7 @@ paths:
         指定したゲーム動画IDのゲーム動画のメタ情報を取得します。
 
   # launcherVersion
-  /launchers/versions:
+  /launchers:
     post:
       tags:
         - launcherVersion
@@ -1010,7 +1010,7 @@ paths:
       summary: ランチャーのバージョン一覧の取得
       description: |
         ランチャーのバージョンの一覧を取得します。
-  /launchers/versions/{launcherVersionID}:
+  /launchers/{launcherVersionID}:
     parameters:
       - $ref: '#/components/parameters/launcherVersionIDInPath'
     get:
@@ -1121,7 +1121,7 @@ paths:
       summary: ランチャーのバージョンの削除
       description: |
         指定したランチャーのバージョンを削除します。
-  /launchers/versions/{launcherVersionID}/games:
+  /launchers/{launcherVersionID}/games:
     parameters:
       - $ref: '#/components/parameters/launcherVersionIDInPath'
     patch:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -302,7 +302,6 @@ paths:
       tags:
         - game
       security:
-        - TrapMemberAuth: []
         - GameMaintainerAuth: []
       operationId: putGame
       requestBody:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -796,13 +796,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: |
-            指定したIDのゲームファイルが存在しない、または削除されている場合に返されます。
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: ゲームファイルの作成
       description: |
         指定したゲームIDのゲームにファイルを作成します。
         作成したゲームファイルは、1日以内にゲームバージョンと紐づけられない場合自動で削除されます。
+    get:
+      tags:
+        - gameFile
+      security:
+        - TrapMemberAuth: []
+      operationId: getGameFiles
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameFile'
+          description: |
+            ゲームファイルの取得に成功した際に返されます。
+            レスポンスで指定されたゲームの
+            アップロード済みゲームファイルのメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームファイル一覧の取得
+      description: |
+        指定したゲームIDのゲームのアップロード済みファイル一覧を返します。
+        ゲームバージョンと紐づけられていないファイルも含まれる点に注意。
   /games/{gameID}/files/{gameFileID}:
     parameters:
       - $ref: '#/components/parameters/gameIDInPath'

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -274,7 +274,7 @@ paths:
         - game
       security:
         - TrapMemberAuth: []
-        - LauncherAuth: []
+        - LauncherGameAuth: []
       operationId: getGame
       responses:
         "200":
@@ -355,6 +355,82 @@ paths:
       description: |
         指定したゲームIDのゲームを削除します。
 
+  # gameRole
+  /games/{gameID}/roles:
+    parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
+    post:
+      tags:
+        - gameRole
+      security:
+        - GameOwnerAuth: []
+      operationId: postGameRole
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GameRole'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameRole'
+          description: |
+            ゲームのロールの作成に成功した際に返されます。
+            レスポンスでロールを作成したゲームのowner、maintainerの一覧が返されます。
+        "400":
+          description: |
+            ゲームID、またはリクエストが不正である場合に返されます。
+            既にmaintainerまたはownerとなっているユーザーが含まれる場合にも返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームの管理権限の追加
+      description: |
+        指定したゲームIDのゲームにowner・maintainerを追加します。
+    delete:
+      tags:
+        - gameRole
+      security:
+        - GameOwnerAuth: []
+      operationId: deleteGameRole
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/GameRole'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameRoleResponse'
+          description: |
+            ゲームの管理権限の削除に成功した際に返されます。
+            レスポンスで管理権限を削除したゲームのowner、maintainerの一覧が返されます。
+        "400":
+          description: |
+            ゲームID、またはリクエストが不正である場合に返されます。
+            指定されたユーザーのうち1人でもownerまたはmaintainerでない場合にも返されます。
+            また、管理権限が削除されるとownerが1人もいなくなる場合にも返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームの管理権限の削除
+      description: |
+        指定したゲームIDのゲームからowner・maintainerを削除します。
+
 components:
   responses:
     TraPUnauthorized:
@@ -409,6 +485,15 @@ components:
       scheme: bearer
       description: |
         ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        アクセストークンが正しく、有効期限が切れていない場合にのみアクセスできます。
+        プロダクトキーがrevokeされた場合、即座に反映されます。
+    LauncherGameAuth:
+      type: http
+      scheme: bearer
+      description: |
+        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        アクセストークンから得られるランチャーのバージョンに、
+        ゲームIDで指定されたゲームが含まれる場合のみアクセスできます。
         プロダクトキーがrevokeされた場合、即座に反映されます。
   parameters:
     authorizationCodeInQuery:
@@ -496,6 +581,21 @@ components:
             $ref: '#/components/schemas/Game'
           description: |
             ゲームの一覧です。
+    GameRoleResponse:
+      type: object
+      properties:
+        owners:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserName'
+          description: |
+            ゲームのownerの一覧です。
+        maintainers:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserName'
+          description: |
+            ゲームのmaintainerの一覧です。
 
     # エンティティ
     # ユーザー
@@ -600,6 +700,30 @@ components:
           description: |
             ゲームとその最新バージョンの情報です。
             ゲームの作成時のレスポンスのみで使用します。
+
+    # ゲーム管理権限
+    GameRole:
+      type: object
+      properties:
+        owners:
+          type: array
+          minLength: 1
+          items:
+            $ref: '#/components/schemas/UserID'
+          description: |
+            ゲームのownerの一覧です。
+        maintainers:
+          type: array
+          minLength: 1
+          items:
+            $ref: '#/components/schemas/UserID'
+          description: |
+            ゲームのmaintainerの一覧です。
+            maintainerがいない場合、このフィールドは存在しません。
+      required:
+        - owners
+      description: |
+        ゲームのownerとmaintainerの一覧です。
 
     # ゲームバージョン
     NewGameVersion:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -182,6 +182,75 @@ paths:
       description: |
         traPのアクティブメンバーの一覧を取得します。
 
+  # admin
+  /admins:
+    patch:
+      tags:
+        - admin
+      security:
+        - AdminAuth: []
+      operationId: patchAdmins
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              minLength: 1
+              items:
+                $ref: '#/components/schemas/UserID'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+          description: |
+            traP Collection全体の管理者の変更に成功した際に返されます。
+            レスポンスで変更後のtraP Collection全体の管理者一覧が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストの形式が正しくない、または、
+            ユーザーIDに対応するユーザーが存在しない場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: traPの管理者一覧の変更
+      description: |
+        traPの管理者一覧を変更します。
+        リクエストボディには管理者にしたいユーザーのIDを配列で渡してください。
+        このAPIは管理者のみが利用できます。
+    get:
+      tags:
+        - admin
+      security:
+        - TrapMemberAuth: []
+      operationId: getAdmins
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+          description: |
+            traP Collection全体の管理者一覧の取得に成功した際に返されます。
+            レスポンスでtraP Collection全体の管理者の一覧が返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: traPの管理者一覧取得
+      description: |
+        traP Collection全体の管理者の一覧を取得します。
+
   # game
   /games:
     post:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -284,11 +284,19 @@ paths:
             ゲームの情報の取得に成功した際に返されます。
             レスポンスで取得したゲームの情報が返されます。
         "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             ゲームIDが不正な値である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
         "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
@@ -317,11 +325,19 @@ paths:
             ゲームの情報の修正に成功した際に返されます。
             レスポンスで修正後のゲームの情報が返されます。
         "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             ゲームID、またはリクエストが不正である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
         "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
@@ -340,11 +356,19 @@ paths:
           description: |
             ゲームの削除に成功した際に返されます。
         "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             ゲームIDが不正な値である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
         "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
@@ -378,12 +402,20 @@ paths:
             ゲームのロールの作成に成功した際に返されます。
             レスポンスでロールを作成したゲームのowner、maintainerの一覧が返されます。
         "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             ゲームID、またはリクエストが不正である場合に返されます。
             既にmaintainerまたはownerとなっているユーザーが含まれる場合にも返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
         "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
@@ -414,6 +446,10 @@ paths:
             ゲームの管理権限の削除に成功した際に返されます。
             レスポンスで管理権限を削除したゲームのowner、maintainerの一覧が返されます。
         "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             ゲームID、またはリクエストが不正である場合に返されます。
             指定されたユーザーのうち1人でもownerまたはmaintainerでない場合にも返されます。
@@ -421,6 +457,10 @@ paths:
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
         "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
@@ -454,11 +494,19 @@ paths:
             ゲームのバージョンの作成に成功した際に返されます。
             レスポンスで作成したゲームのバージョンが返されます。
         "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             ゲームID、またはリクエストが不正である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
         "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
@@ -501,11 +549,19 @@ paths:
             ゲームバージョン一覧の取得に成功した際に返されます。
             レスポンスで取得したゲームバージョンの一覧が返されます。
         "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             ゲームIDが不正である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
         "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
@@ -533,11 +589,19 @@ paths:
             ゲームの最新バージョンの取得に成功した際に返されます。
             レスポンスで取得したゲームの最新バージョンが返されます。
         "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             ゲームIDが不正である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
         "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
             指定したIDのゲームが存在しない、または削除されている場合に返されます。
             また、API v1で追加され、バージョンが存在しないゲームであった場合にも返されます。
@@ -546,6 +610,130 @@ paths:
       summary: ゲームの最新バージョンの取得
       description: |
         指定したゲームIDのゲームの最新バージョンを取得します。
+
+  # gameFile
+  /games/files:
+    post:
+      tags:
+        - gameFile
+      security:
+        - TrapMemberAuth: []
+      operationId: postGameFile
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/NewGameFile'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameFile'
+          description: |
+            ゲームファイルの作成に成功した際に返されます。
+            レスポンスで作成したゲームファイルのメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームファイルの作成
+      description: |
+        指定したゲームIDのゲームにファイルを作成します。
+        作成したゲームファイルは、ゲームのバージョンに紐付けられます。
+  /games/files/{gameFileID}:
+    parameters:
+      - $ref: '#/components/parameters/gameFileIDInPath'
+    get:
+      tags:
+        - gameFile
+      security:
+        - TrapMemberAuth: []
+        - LauncherGameFileAuth: []
+      operationId: getGameFile
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/GameFileContent'
+          description: |
+            ゲームファイルの取得に成功した際に返されます。
+            レスポンスで取得したゲームファイルのバイナリが返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            ファイルIDが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲームファイルが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームファイルのバイナリの取得
+      description: |
+        指定したゲームファイルIDのゲームファイルを取得します。
+  /games/files/{gameFileID}/meta:
+    parameters:
+      - $ref: '#/components/parameters/gameFileIDInPath'
+    get:
+      tags:
+        - gameFile
+      security:
+        - TrapMemberAuth: []
+      operationId: getGameFileMeta
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/GameFile'
+          description: |
+            ゲームファイルのメタ情報の取得に成功した際に返されます。
+            レスポンスで取得したゲームファイルのメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            ファイルIDが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲームファイルが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームファイルのメタ情報の取得
+      description: |
+        指定したゲームファイルIDのゲームファイルを取得します。
 
 components:
   responses:
@@ -611,6 +799,30 @@ components:
         アクセストークンから得られるランチャーのバージョンに、
         ゲームIDで指定されたゲームが含まれる場合のみアクセスできます。
         プロダクトキーがrevokeされた場合、即座に反映されます。
+    LauncherGameFileAuth:
+      type: http
+      scheme: bearer
+      description: |
+        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        アクセストークンから得られるランチャーのバージョンに、
+        ファイルIDで指定されたファイルに対応するゲームが含まれる場合のみアクセスできます。
+        プロダクトキーがrevokeされた場合、即座に反映されます。
+    LauncherGameImageAuth:
+      type: http
+      scheme: bearer
+      description: |
+        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        アクセストークンから得られるランチャーのバージョンに、
+        画像IDで指定された画像に対応するゲームが含まれる場合のみアクセスできます。
+        プロダクトキーがrevokeされた場合、即座に反映されます。
+    LauncherGameVideoAuth:
+      type: http
+      scheme: bearer
+      description: |
+        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        アクセストークンから得られるランチャーのバージョンに、
+        動画IDで指定された動画に対応するゲームが含まれる場合のみアクセスできます。
+        プロダクトキーがrevokeされた場合、即座に反映されます。
   parameters:
     authorizationCodeInQuery:
       name: code
@@ -654,7 +866,7 @@ components:
         type: string
         format: uuid
       description: |
-        ゲームのバージョンのIDを示すパスパラメータです。
+        ゲームのファイルのIDを示すパスパラメータです。
     productKeyIDInPath:
       name: productKeyID
       in: path
@@ -918,11 +1130,28 @@ components:
         url、filesはゲームの種類に応じていずれかが存在します。
 
     # ゲームファイル
+    NewGameFile:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GameFileType'
+        entryPoint:
+          $ref: '#/components/schemas/GameFileEntryPoint'
+        content:
+          $ref: '#/components/schemas/GameFileContent'
+      required:
+        - type
+        - entryPoint
+        - content
+      description: |
+        ゲームのファイルを新しく作成する際に必要な情報です。
     GameFile:
       type: object
       properties:
         id:
           $ref: '#/components/schemas/GameFileID'
+        type:
+          $ref: '#/components/schemas/GameFileType'
         md5:
           $ref: '#/components/schemas/GameFileMd5'
         entryPoint:
@@ -931,11 +1160,12 @@ components:
           $ref: '#/components/schemas/GameFileCreatedAt'
       required:
         - id
+        - type
         - md5
         - entryPoint
         - createdAt
       description: |
-        ゲームのファイルです。
+        ゲームのファイルのメタ情報です。
 
     # 値オブジェクト
     # ユーザー
@@ -1017,6 +1247,17 @@ components:
       format: uuid
       description: |
         ゲームファイルのIDです。
+    GameFileType:
+      type: string
+      enum:
+        - jar
+        - win32
+        - darwin
+      description: |
+        ゲームファイルのタイプです。
+        jarはJavaで起動しWindows、OSXの両方で実行できるもの、
+        windowsはWindows用の実行ファイル、
+        macはOSX用の実行ファイルです。
     GameFileMd5:
       type: string
       pattern: ^[0-9a-f]{32}$

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -58,7 +58,7 @@ paths:
         - oauth2
       operationId: getCallback
       responses:
-        "204":
+        "200":
           description: |
             認証が成功した場合に返されます。
             セッションにユーザー情報が保存され、セッションが切れるまでログイン状態になります。
@@ -112,7 +112,7 @@ paths:
         - TrapMemberAuth: []
       operationId: postLogout
       responses:
-        "204":
+        "200":
           description: |
             ログアウトに成功した場合に返されます。
             セッションが削除されます。
@@ -352,7 +352,7 @@ paths:
         - GameOwnerAuth: []
       operationId: deleteGames
       responses:
-        "204":
+        "200":
           description: |
             ゲームの削除に成功した際に返されます。
         "400":
@@ -1096,7 +1096,7 @@ paths:
         - AdminAuth: []
       operationId: deleteLauncherVersion
       responses:
-        "204":
+        "200":
           description: |
             ランチャーのバージョンの削除に成功した際に返されます。
         "400":

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -2435,10 +2435,13 @@ components:
           $ref: '#/components/schemas/ProductKeyValue'
         status:
           $ref: '#/components/schemas/ProductKeyStatus'
+        createdAt:
+          $ref: '#/components/schemas/ProductKeyCreatedAt'
       required:
         - id
         - key
         - status
+        - createdAt
     EditionAccessToken:
       type: object
       properties:
@@ -2683,6 +2686,11 @@ components:
       enum:
         - active
         - revoked
+    ProductKeyCreatedAt:
+      type: string
+      format: date-time
+      description: |
+        プロダクトキーが作成された時刻です。
     EditionAccessTokenValue:
       type: string
       maxLength: 36

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -26,6 +26,7 @@ tags:
   - name: seat
 
 paths:
+  # oauth2
   /oauth2/callback:
     parameters:
       - $ref: '#/components/parameters/authorizationCodeInQuery'
@@ -110,6 +111,7 @@ paths:
         traP Collectionの管理画面からログアウトします。
         成功するとセッションが削除されます。
 
+  # user
   /users/me:
     get:
       tags:
@@ -157,6 +159,7 @@ paths:
       description: |
         traPのアクティブメンバーの一覧を取得します。
 
+  # game
   /games:
     post:
       tags:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -758,7 +758,9 @@ paths:
         指定したゲームIDのゲームの最新バージョンを取得します。
 
   # gameFile
-  /games/files:
+  /games/{gameID}/files:
+    parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
     post:
       tags:
         - gameFile
@@ -801,8 +803,9 @@ paths:
       description: |
         指定したゲームIDのゲームにファイルを作成します。
         作成したゲームファイルは、1日以内にゲームバージョンと紐づけられない場合自動で削除されます。
-  /games/files/{gameFileID}:
+  /games/{gameID}/files/{gameFileID}:
     parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
       - $ref: '#/components/parameters/gameFileIDInPath'
     get:
       tags:
@@ -848,8 +851,9 @@ paths:
       summary: ゲームファイルのバイナリの取得
       description: |
         指定したゲームファイルIDのゲームファイルを取得します。
-  /games/files/{gameFileID}/meta:
+  /games/{gameID}/files/{gameFileID}/meta:
     parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
       - $ref: '#/components/parameters/gameFileIDInPath'
     get:
       tags:
@@ -897,7 +901,9 @@ paths:
         指定したゲームファイルIDのゲームファイルを取得します。
 
   # gameImage
-  /games/images:
+  /games/{gameID}/images:
+    parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
     post:
       tags:
         - gameImage
@@ -940,8 +946,9 @@ paths:
       description: |
         指定したゲームIDのゲームに画像を作成します。
         作成したゲーム画像は、1日以内にゲームバージョンと紐づけられない場合に自動で削除されます。
-  /games/images/{gameImageID}:
+  /games/{gameID}/images/{gameImageID}:
     parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
       - $ref: '#/components/parameters/gameImageIDInPath'
     get:
       tags:
@@ -987,8 +994,9 @@ paths:
       summary: ゲーム画像のバイナリの取得
       description: |
         指定したゲーム画像IDのゲーム画像を取得します。
-  /games/images/{gameImageID}/meta:
+  /games/{gameID}/images/{gameImageID}/meta:
     parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
       - $ref: '#/components/parameters/gameImageIDInPath'
     get:
       tags:
@@ -1036,7 +1044,9 @@ paths:
         指定したゲーム画像IDのゲーム画像のメタ情報を取得します。
 
   # gameVideo
-  /games/videos:
+  /games/{gameID}/videos:
+    parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
     post:
       tags:
         - gameVideo
@@ -1079,8 +1089,9 @@ paths:
       description: |
         指定したゲームIDのゲームに動画を作成します。
         作成したゲーム動画は、1日以内にゲームバージョンと紐づけられない場合に自動で削除されます。
-  /games/videos/{gameVideoID}:
+  /games/{gameID}/videos/{gameVideoID}:
     parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
       - $ref: '#/components/parameters/gameVideoIDInPath'
     get:
       tags:
@@ -1126,8 +1137,9 @@ paths:
       summary: ゲーム動画のバイナリの取得
       description: |
         指定したゲーム動画IDのゲーム動画を取得します。
-  /games/videos/{gameVideoID}/meta:
+  /games/{gameID}/videos/{gameVideoID}/meta:
     parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
       - $ref: '#/components/parameters/gameVideoIDInPath'
     get:
       tags:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -290,8 +290,14 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             ゲームIDが不正な値である場合に返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            traQのOAuth 2.0による認証が通過できない、かつ、
+            ランチャーのアクセストークンによるBearer認証も通過できない場合に返されます。
         "404":
           content:
             application/json:
@@ -333,6 +339,13 @@ paths:
             ゲームID、またはリクエストが不正である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            このゲームのmaintainer、ownerのどちらでもない場合に返されます。
         "404":
           content:
             application/json:
@@ -364,6 +377,13 @@ paths:
             ゲームIDが不正な値である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            このゲームのownerでない場合に返されます。
         "404":
           content:
             application/json:
@@ -411,6 +431,13 @@ paths:
             既にmaintainerまたはownerとなっているユーザーが含まれる場合にも返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            このゲームのownerでない場合に返されます。
         "404":
           content:
             application/json:
@@ -459,6 +486,13 @@ paths:
             ゲームファイルの種類とwindows,darwin,jarの対応が誤っている場合もこのエラーとなります。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            このゲームのmaintainer、ownerのどちらでもない場合に返されます。
         "404":
           content:
             application/json:
@@ -638,8 +672,14 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             ファイルIDが不正である場合に返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            traQのOAuth 2.0認証を通過できず、かつ、
+            ランチャーの認証を通過できないまたはランチャーにこのファイルに対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -678,8 +718,14 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             ファイルIDが不正である場合に返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            traQのOAuth 2.0認証を通過できず、かつ、
+            ランチャーの認証を通過できないまたはランチャーにこのファイルに対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -763,8 +809,14 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             画像IDが不正である場合に返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            traQのOAuth 2.0認証を通過できず、かつ、
+            ランチャーの認証を通過できないまたはランチャーにこの画像に対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -803,8 +855,14 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             画像IDが不正である場合に返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            traQのOAuth 2.0認証を通過できず、かつ、
+            ランチャーの認証を通過できないまたはランチャーにこの画像に対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -888,8 +946,14 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             動画IDが不正である場合に返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            traQのOAuth 2.0認証を通過できず、かつ、
+            ランチャーの認証を通過できないまたはランチャーにこの動画に対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -928,8 +992,14 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             動画IDが不正である場合に返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            traQのOAuth 2.0認証を通過できず、かつ、
+            ランチャーの認証を通過できないまたはランチャーにこの動画に対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -974,6 +1044,8 @@ paths:
             リクエストが不正である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          $ref: '#/components/responses/AdminForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: ランチャーのバージョンの作成
@@ -1078,6 +1150,8 @@ paths:
             リクエストが不正である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          $ref: '#/components/responses/AdminForbidden'
         "404":
           content:
             application/json:
@@ -1109,6 +1183,8 @@ paths:
             リクエストが不正である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          $ref: '#/components/responses/AdminForbidden'
         "404":
           content:
             application/json:
@@ -1155,6 +1231,8 @@ paths:
             リクエストが不正である場合に返されます。
         "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          $ref: '#/components/responses/AdminForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: ランチャーバージョンのゲームの変更
@@ -1185,8 +1263,15 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             リクエストが不正である場合に返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            traQのOAuth 2.0認証を通過できない、かつ、
+            ランチャーのアクセストークンによるBearer認証を通過できない、
+            または、アクセストークンに対応するランチャーバージョンとlauncherIDが一致しない場合に返されます。
         "404":
           content:
             application/json:
@@ -1230,8 +1315,10 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             リクエストが不正である場合に返されます。
-        "403":
+        "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          $ref: '#/components/responses/AdminForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: ランチャーのプロダクトキーの生成
@@ -1263,8 +1350,10 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             リクエストが不正である場合に返されます。
-        "403":
+        "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          $ref: '#/components/responses/AdminForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: ランチャーのプロダクトキーの一覧の取得
@@ -1296,8 +1385,10 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             リクエストが不正である場合に返されます。
-        "403":
+        "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          $ref: '#/components/responses/AdminForbidden'
         "404":
           content:
             application/json:
@@ -1336,8 +1427,10 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             リクエストが不正である場合に返されます。
-        "403":
+        "401":
           $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          $ref: '#/components/responses/AdminForbidden'
         "404":
           content:
             application/json:
@@ -1377,8 +1470,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             リクエストが不正である場合に返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          $ref: '#/components/responses/LauncherForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: ランチャーの認可リクエスト
@@ -1425,6 +1518,13 @@ components:
       description: |
         traQのOAuth 2.0での認証がされていない、
         もしくは認証したが既にセッションが切れている場合に返されます。
+    AdminForbidden:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        adminでない場合に返されます。
     LauncherForbidden:
       content:
         application/json:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -266,6 +266,7 @@ paths:
       summary: ゲーム一覧の取得
       description: |
         ゲームの一覧を取得します。
+        作成時刻での降順で結果が返されます。
   /games/{gameID}:
     parameters:
       - $ref: '#/components/parameters/gameIDInPath'
@@ -431,6 +432,124 @@ paths:
       description: |
         指定したゲームIDのゲームからowner・maintainerを削除します。
 
+  # gameVersion
+  /games/{gameID}/versions:
+    parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
+    post:
+      tags:
+        - gameVersion
+      security:
+        - GameMaintainerAuth: []
+      operationId: postGameVersion
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewGameVersion'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameVersion'
+          description: |
+            ゲームのバージョンの作成に成功した際に返されます。
+            レスポンスで作成したゲームのバージョンが返されます。
+        "400":
+          description: |
+            ゲームID、またはリクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームのバージョンの作成
+      description: |
+        指定したゲームIDのゲームにバージョンを作成します。
+    get:
+      tags:
+        - gameVersion
+      security:
+        - TrapMemberAuth: []
+      operationId: getGameVersion
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          description: |
+            取得するゲームバージョンの上限数を指定します。
+            指定なしの場合は制限なしです。
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+          description: |
+            取得するゲームバージョンの開始位置を指定します。
+            指定なしの場合は0となります。
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetGameVersionsResponse'
+          description: |
+            ゲームバージョン一覧の取得に成功した際に返されます。
+            レスポンスで取得したゲームバージョンの一覧が返されます。
+        "400":
+          description: |
+            ゲームIDが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームバージョン一覧の取得
+      description: |
+        指定したゲームIDのゲームのバージョン一覧を取得します。
+        作成時刻での降順で結果が返されます。
+  /games/{gameID}/versions/latest:
+    parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
+    get:
+      tags:
+        - gameVersion
+      security:
+        - TrapMemberAuth: []
+      operationId: getLatestGameVersion
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameVersion'
+          description: |
+            ゲームの最新バージョンの取得に成功した際に返されます。
+            レスポンスで取得したゲームの最新バージョンが返されます。
+        "400":
+          description: |
+            ゲームIDが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+            また、API v1で追加され、バージョンが存在しないゲームであった場合にも返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームの最新バージョンの取得
+      description: |
+        指定したゲームIDのゲームの最新バージョンを取得します。
+
 components:
   responses:
     TraPUnauthorized:
@@ -530,8 +649,8 @@ components:
         format: uuid
       description: |
         ゲームのIDを示すパスパラメータです。
-    gameVersionIDInPath:
-      name: gameVersionID
+    gameFileIDInPath:
+      name: gameFileID
       in: path
       required: true
       schema:
@@ -589,26 +708,25 @@ components:
       description: |
         ゲームの一覧を取得します。
         ページングのために、limit、offsetを適用する前のゲームの数をnumで返しています。
-    GameRoleResponse:
+    GetGameVersionsResponse:
       type: object
       properties:
-        owners:
+        num:
+          type: integer
+          description: |
+            limit、offsetが適用される前のゲームバージョンの数です。
+        versions:
           type: array
           items:
-            $ref: '#/components/schemas/UserName'
+            $ref: '#/components/schemas/GameVersion'
           description: |
-            ゲームのownerの一覧です。
-        maintainers:
-          type: array
-          items:
-            $ref: '#/components/schemas/UserName'
-          description: |
-            ゲームのmaintainerの一覧です。
-            maintainerがいない場合、このフィールドは存在しません。
+            limit、offsetが適用された後のゲームバージョンの一覧です。
       required:
-        - owners
+        - num
+        - versions
       description: |
-        ゲームのownerとmaintainerの一覧です。
+        ゲームバージョンの一覧を取得します。
+        ページングのために、limit、offsetを適用する前のゲームバージョンの数もnumで返しています。
 
     # エンティティ
     # ユーザー
@@ -751,8 +869,12 @@ components:
           $ref: '#/components/schemas/GameVersionDescription'
         url:
           $ref: '#/components/schemas/GameURL'
-        file:
-          $ref: '#/components/schemas/GameFileGroup'
+        files:
+          type: array
+          minLength: 1
+          maxLength: 3
+          items:
+            $ref: '#/components/schemas/GameFileID'
         imageID:
           $ref: '#/components/schemas/GameImageID'
         videoID:
@@ -763,8 +885,8 @@ components:
         - imageID
         - videoID
       description: |
-        新しいゲームのバージョンです。
-        url、fileはゲームの種類に応じていずれかが存在します。
+        新しいゲームのバージョンの作成に必要な情報です。
+        url、filesはゲームの種類に応じていずれかが存在します。
     GameVersion:
       type: object
       properties:
@@ -792,6 +914,29 @@ components:
         - id
         - name
         - description
+        - imageID
+        - videoID
+        - createdAt
+      description: |
+        ゲームのバージョンです。
+        url、filesはゲームの種類に応じていずれかが存在します。
+
+    # ゲームファイル
+    GameFile:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/GameFileID'
+        md5:
+          $ref: '#/components/schemas/GameFileMd5'
+        entryPoint:
+          $ref: '#/components/schemas/GameFileEntryPoint'
+        createdAt:
+          $ref: '#/components/schemas/GameFileCreatedAt'
+      required:
+        - id
+        - md5
+        - entryPoint
         - createdAt
       description: |
         ゲームのファイルです。

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -25,7 +25,7 @@ tags:
       ゲーム関連のAPIです。
   - name: gameRole
     description: |
-      ゲームの操作権限関連のAPIです。
+      ゲームの管理権限関連のAPIです。
   - name: gameVersion
     description: |
       ゲームのバージョン関連のAPIです。
@@ -43,7 +43,7 @@ tags:
       ランチャーのバージョン関連のAPIです。
   - name: launcherAuth
     description: |
-      ランチャーの認証関連のAPIです。
+      ランチャーの認可関連のAPIです。
   - name: seat
     description: |
       席管理関連のAPIです。
@@ -58,7 +58,7 @@ paths:
         - oauth2
       operationId: getCallback
       responses:
-        "200":
+        "204":
           description: |
             認証が成功した場合に返されます。
             セッションにユーザー情報が保存され、セッションが切れるまでログイン状態になります。
@@ -112,7 +112,7 @@ paths:
         - TrapMemberAuth: []
       operationId: postLogout
       responses:
-        "200":
+        "204":
           description: |
             ログアウトに成功した場合に返されます。
             セッションが削除されます。
@@ -342,7 +342,7 @@ paths:
             指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ゲームの情報の修正
+      summary: ゲームの情報の変更
       description: |
         指定したゲームIDのゲームの情報を修正します。
     delete:
@@ -352,7 +352,7 @@ paths:
         - GameOwnerAuth: []
       operationId: deleteGames
       responses:
-        "200":
+        "204":
           description: |
             ゲームの削除に成功した際に返されます。
         "400":
@@ -381,7 +381,7 @@ paths:
   /games/{gameID}/roles:
     parameters:
       - $ref: '#/components/parameters/gameIDInPath'
-    post:
+    patch:
       tags:
         - gameRole
       security:
@@ -393,14 +393,14 @@ paths:
             schema:
               $ref: '#/components/schemas/GameRole'
       responses:
-        "201":
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GameRole'
           description: |
-            ゲームのロールの作成に成功した際に返されます。
-            レスポンスでロールを作成したゲームのowner、maintainerの一覧が返されます。
+            ゲームの管理権限の変更に成功した際に返されます。
+            レスポンスで変更後のowner、maintainerの一覧が返されます。
         "400":
           content:
             application/json:
@@ -420,54 +420,10 @@ paths:
             指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ゲームの管理権限の追加
+      summary: ゲームの管理権限の変更
       description: |
-        指定したゲームIDのゲームにowner・maintainerを追加します。
-    delete:
-      tags:
-        - gameRole
-      security:
-        - GameOwnerAuth: []
-      operationId: deleteGameRole
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/GameRole'
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GameRoleResponse'
-          description: |
-            ゲームの管理権限の削除に成功した際に返されます。
-            レスポンスで管理権限を削除したゲームのowner、maintainerの一覧が返されます。
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: |
-            ゲームID、またはリクエストが不正である場合に返されます。
-            指定されたユーザーのうち1人でもownerまたはmaintainerでない場合にも返されます。
-            また、管理権限が削除されるとownerが1人もいなくなる場合にも返されます。
-        "401":
-          $ref: '#/components/responses/TraPUnauthorized'
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: |
-            指定したIDのゲームが存在しない、または削除されている場合に返されます。
-        "500":
-          $ref: '#/components/responses/InternalServerError'
-      summary: ゲームの管理権限の削除
-      description: |
-        指定したゲームIDのゲームからowner・maintainerを削除します。
+        指定したゲームIDのゲームの管理権限を変更します。
+        ownerは1人以上はいる必要があります。
 
   # gameVersion
   /games/{gameID}/versions:
@@ -986,6 +942,262 @@ paths:
       description: |
         指定したゲーム動画IDのゲーム動画のメタ情報を取得します。
 
+  # launcherVersion
+  /launchers/versions:
+    post:
+      tags:
+        - launcherVersion
+      security:
+        - AdminAuth: []
+      operationId: postLauncherVersion
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewLauncherVersion'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LauncherVersion'
+          description: |
+            ランチャーのバージョンの作成に成功した際に返されます。
+            レスポンスで作成したランチャーのバージョンのメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのバージョンの作成
+      description: |
+        ランチャーのバージョンを作成します。
+    get:
+      tags:
+        - launcherVersion
+      security:
+        - TrapMemberAuth: []
+      operationId: getLauncherVersions
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LauncherVersion'
+          description: |
+            ランチャーのバージョンの取得に成功した際に返されます。
+            レスポンスで取得したランチャーのバージョンのリストが返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのバージョン一覧の取得
+      description: |
+        ランチャーのバージョンの一覧を取得します。
+  /launchers/versions/{launcherVersionID}:
+    parameters:
+      - $ref: '#/components/parameters/launcherVersionIDInPath'
+    get:
+      tags:
+        - launcherVersion
+      security:
+        - TrapMemberAuth: []
+      operationId: getLauncherVersion
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LauncherVersion'
+          description: |
+            ランチャーのバージョンの取得に成功した際に返されます。
+            レスポンスで取得したランチャーのバージョンのメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのランチャーのバージョンが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのバージョン情報の取得
+      description: |
+        指定したランチャーのバージョンIDのランチャーのバージョンのメタ情報を取得します。
+    patch:
+      tags:
+        - launcherVersion
+      security:
+        - AdminAuth: []
+      operationId: patchLauncherVersion
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchLauncherVersion'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LauncherVersion'
+          description: |
+            ランチャーのバージョンの変更に成功した際に返されます。
+            レスポンスで変更したランチャーのバージョンのメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのランチャーのバージョンが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのバージョン情報の変更
+      description: |
+        指定したランチャーのバージョンIDのランチャーのバージョンの情報を変更します。
+    delete:
+      tags:
+        - launcherVersion
+      security:
+        - AdminAuth: []
+      operationId: deleteLauncherVersion
+      responses:
+        "204":
+          description: |
+            ランチャーのバージョンの削除に成功した際に返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのランチャーのバージョンが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのバージョンの削除
+      description: |
+        指定したランチャーのバージョンを削除します。
+  /launchers/versions/{launcherVersionID}/games:
+    parameters:
+      - $ref: '#/components/parameters/launcherVersionIDInPath'
+    patch:
+      tags:
+        - launcherVersion
+      security:
+        - AdminAuth: []
+      operationId: postLauncherVersionGame
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchLauncherVersionGameRequest'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LauncherVersionGameResponse'
+          description: |
+            ランチャーのバージョンのゲームの変更に成功した際に返されます。
+            レスポンスで変更後のランチャーのバージョンに紐づいたゲームとゲームバージョン一覧が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーバージョンのゲームの変更
+      description: |
+        ランチャーバージョンにゲームを追加します。
+    get:
+      tags:
+        - launcherVersion
+      security:
+        - TrapMemberAuth: []
+      operationId: getLauncherVersionGames
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LauncherVersionGameResponse'
+          description: |
+            ランチャーのバージョンに紐づくゲームとバージョンの一覧の取得に成功した際に返されます。
+            レスポンスで取得したゲームとバージョンのリストが返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのランチャーのバージョンが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ランチャーのバージョンに紐づくゲームの一覧の取得
+      description: |
+        ランチャーのバージョンに紐づくゲームの一覧を取得します。
+
 components:
   responses:
     TraPUnauthorized:
@@ -1213,6 +1425,30 @@ components:
       description: |
         ゲームバージョンの一覧を取得します。
         ページングのために、limit、offsetを適用する前のゲームバージョンの数もnumで返しています。
+    PatchLauncherVersionGameRequest:
+      type: object
+      properties:
+        gameVersionIDs:
+          type: array
+          items:
+            $ref: '#/components/schemas/GameVersionID'
+      required:
+        - gameVersionIDs
+      description: |
+        ランチャーのバージョンのゲームを変更するためのリクエストです。
+    LauncherVersionGameResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/GameInfo'
+        - type: object
+          properties:
+            version:
+              $ref: '#/components/schemas/GameVersionInfo'
+          required:
+            - version
+      description: |
+        ランチャーのバージョンに紐づけられた
+        ゲームとバージョンの情報です。
 
     # エンティティ
     # ユーザー
@@ -1307,6 +1543,24 @@ components:
         - createdAt
       description: |
         ゲームの情報です。
+    GameInfo:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/GameID'
+        name:
+          $ref: '#/components/schemas/GameName'
+        description:
+          $ref: '#/components/schemas/GameDescription'
+        createdAt:
+          $ref: '#/components/schemas/GameCreatedAt'
+      required:
+        - id
+        - name
+        - description
+        - createdAt
+      description: |
+        ゲームの情報です。
 
     # ゲーム管理権限
     GameRole:
@@ -1393,6 +1647,30 @@ components:
       description: |
         ゲームのバージョンです。
         url、filesはゲームの種類に応じていずれかが存在します。
+    GameVersionInfo:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/GameVersionID'
+        name:
+          $ref: '#/components/schemas/GameVersionName'
+        description:
+          $ref: '#/components/schemas/GameVersionDescription'
+        imageID:
+          $ref: '#/components/schemas/GameImageID'
+        videoID:
+          $ref: '#/components/schemas/GameVideoID'
+        createdAt:
+          $ref: '#/components/schemas/GameVersionCreatedAt'
+      required:
+        - id
+        - name
+        - description
+        - imageID
+        - videoID
+        - createdAt
+      description: |
+        ゲームのバージョンについての情報です。
 
     # ゲームファイル
     NewGameFile:
@@ -1489,6 +1767,54 @@ components:
         - createdAt
       description: |
         ゲームの動画のメタ情報です。
+
+    # ランチャーバージョン
+    PatchLauncherVersion:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/LauncherVersionName'
+        questionnaire:
+          $ref: '#/components/schemas/LauncherVersionQuestionnaireURL'
+      required:
+        - name
+        - questionnaire
+      description: |
+        ランチャーバージョンの情報を修正する際に必要な情報です。
+    NewLauncherVersion:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/LauncherVersionName'
+        questionnaire:
+          $ref: '#/components/schemas/LauncherVersionQuestionnaireURL'
+        gameVersions:
+          type: array
+          items:
+            $ref: '#/components/schemas/GameVersionID'
+      required:
+        - name
+      description: |
+        ランチャーのバージョンを新しく作成する際に必要な情報です。
+        questionnaireは工大祭などのアンケートが必要な際のみ存在します。
+    LauncherVersion:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/LauncherVersionID'
+        name:
+          $ref: '#/components/schemas/LauncherVersionName'
+        questionnaire:
+          $ref: '#/components/schemas/LauncherVersionQuestionnaireURL'
+        createdAt:
+          $ref: '#/components/schemas/LauncherVersionCreatedAt'
+      required:
+        - id
+        - name
+        - createdAt
+      description: |
+        ランチャーのバージョンです。
+        questionnaireは工大祭などのアンケートが必要な際のみ存在します。
 
     # 値オブジェクト
     # ユーザー
@@ -1657,3 +1983,25 @@ components:
       format: date-time
       description: |
         ゲーム紹介動画の作成時刻です。
+
+    # ランチャーバージョン
+    LauncherVersionID:
+      type: string
+      format: uuid
+      description: |
+        ランチャーのバージョンのIDです。
+    LauncherVersionName:
+      type: string
+      maxLength: 32
+      description: |
+        ランチャーのバージョン名です。
+    LauncherVersionQuestionnaireURL:
+      type: string
+      format: uri
+      description: |
+        ランチャーのバージョンのアンケートのURLです。
+    LauncherVersionCreatedAt:
+      type: string
+      format: date-time
+      description: |
+        ランチャーのバージョンが作成された時刻です。

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -977,13 +977,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: |
-            指定したIDのゲーム画像が存在しない、または削除されている場合に返されます。
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: ゲーム画像の作成
       description: |
         指定したゲームIDのゲームに画像を作成します。
         作成したゲーム画像は、1日以内にゲームバージョンと紐づけられない場合に自動で削除されます。
+    get:
+      tags:
+        - gameImage
+      security:
+        - TrapMemberAuth: []
+      operationId: getGameImages
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameImage'
+          description: |
+            ゲーム画像一覧の取得に成功した際に返されます。
+            レスポンスで指定したゲームの
+            アップロード済みゲーム画像のメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲーム画像一覧の取得
+      description: |
+        指定したゲームIDのアップロード済みゲーム画像一覧を返します。
+        ゲームバージョンに紐づけられていないゲーム画像も含まれる点に注意。
   /games/{gameID}/images/{gameImageID}:
     parameters:
       - $ref: '#/components/parameters/gameIDInPath'

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -184,20 +184,17 @@ paths:
 
   # admin
   /admins:
-    patch:
+    post:
       tags:
         - admin
       security:
         - AdminAuth: []
-      operationId: patchAdmins
+      operationId: postAdmin
       requestBody:
         content:
           application/json:
             schema:
-              type: array
-              minLength: 1
-              items:
-                $ref: '#/components/schemas/UserID'
+              $ref: '#/components/schemas/UserRequest'
       responses:
         "200":
           content:
@@ -207,7 +204,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/User'
           description: |
-            traP Collection全体の管理者の変更に成功した際に返されます。
+            traP Collection全体の管理者の追加に成功した際に返されます。
             レスポンスで変更後のtraP Collection全体の管理者一覧が返されます。
         "400":
           content:
@@ -221,10 +218,47 @@ paths:
           $ref: '#/components/responses/TraPUnauthorized'
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: traPの管理者一覧の変更
+      summary: traP Collection全体の管理者追加
       description: |
-        traPの管理者一覧を変更します。
-        リクエストボディには管理者にしたいユーザーのIDを配列で渡してください。
+        traP Collection全体の管理者を追加します。
+        このAPIは管理者のみが利用できます。
+    delete:
+      tags:
+        - admin
+      security:
+        - AdminAuth: []
+      operationId: deleteAdmin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+          description: |
+            traP Collection全体の管理者の削除に成功した際に返されます。
+            レスポンスで変更後のtraP Collection全体の管理者一覧が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストの形式が正しくない、または、
+            ユーザーIDに対応するユーザーが存在しない場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: traP Collection全体の管理者削除
+      description: |
+        traP Collection全体の管理者を削除します。
         このAPIは管理者のみが利用できます。
     get:
       tags:
@@ -1893,6 +1927,15 @@ components:
           example: Internal Server Error
       required:
         - message
+    UserRequest:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UserID'
+      required:
+        - id
+      description: |
+        ユーザーを指定するリクエストです。
     PostGameResponse:
       type: object
       allOf:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -1165,6 +1165,44 @@ paths:
       description: |
         指定したゲームIDのゲームに動画を作成します。
         作成したゲーム動画は、1日以内にゲームバージョンと紐づけられない場合に自動で削除されます。
+    get:
+      tags:
+        - gameVideo
+      security:
+        - TrapMemberAuth: []
+      operationId: getGameVideos
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameVideo'
+          description: |
+            ゲーム動画の一覧取得に成功した際に返されます。
+            レスポンスで指定したゲームの
+            アップロード済みゲーム動画のメタ情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            リクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲーム動画が存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲーム動画一覧の取得
+      description: |
+        指定したゲームIDのゲームのアップロード済み動画一覧を取得します。
+        ゲームバージョンに紐づけられていなくても一覧に含まれる点に注意。
   /games/{gameID}/videos/{gameVideoID}:
     parameters:
       - $ref: '#/components/parameters/gameIDInPath'

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -1,0 +1,298 @@
+openapi: "3.0.3"
+servers:
+  - url: https://collection.trap.jp/api/v2
+  - url: https://collection-dev.trapti.tech/api/v2
+  - url: http://localhost:3000/api/v2
+info:
+  description: 'traP Collection v2'
+  version: '2.0.0'
+  title: 'traP Collection v2'
+  contact:
+    name: traP
+    url: 'https://github.com/traPtitech/trap-collection-server'
+tags:
+  - name: oauth2
+  - name: user
+  - name: admin
+  - name: game
+  - name: gameRole
+  - name: gameVersion
+  - name: gameFile
+  - name: gameURL
+  - name: gameImage
+  - name: gameVideo
+  - name: version
+  - name: launcherAuth
+  - name: seat
+
+paths:
+  /oauth2/callback:
+    parameters:
+      - $ref: '#/components/parameters/authorizationCodeInQuery'
+    get:
+      tags:
+        - oauth2
+      operationId: getCallback
+      responses:
+        "200":
+          description: |
+            認証が成功した場合に返されます。
+            セッションにユーザー情報が保存され、セッションが切れるまでログイン状態になります。
+            また、Code Challengeなどは削除されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            セッション、またはAuthorization Codeになんらかの誤りがあり、
+            認証に失敗した場合に返されます。
+            誤りの内容はレスポンスのmessageに出力されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: traQのOAuth 2.0のコールバック
+      description: |
+        traQ上での認証後にtraQから
+        Authorization Codeがクエリパラメーターにつけられて、
+        リダイレクトされます。
+  /oauth2/code:
+    get:
+      tags:
+        - oauth2
+      operationId: getCode
+      responses:
+        "303":
+          headers:
+            Set-Cookie:
+              schema: 
+                type: string
+                example: sessions=abcd1234; Path=/; Expires=Wed, 04 May 2022 16:24:11 GMT; Max-Age=2592000; HttpOnly; Secure
+            Location:
+              schema:
+                type: string
+                example: https://q.trap.jp/api/v3/oauth2/authorize?response_type=code&client_id=<ClientID>&code_challenge=<Code Challenge>&code_challenge_method=S256
+          description: |
+            セッションの設定などに成功した場合に返されます。
+            traQの認可ページにリダイレクトされます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: OAuth 2.0のCode Verifierなどのセッションへの設定とtraQへのリダイレクト
+      description: |
+        OAuth 2.0を利用しての認証に必要なPKCEのCode Verifierを生成し、
+        セッションに設定した上でCode ChallengeやClientIDなどを設定したtraQのURLへリダイレクトします。
+  /oauth2/logout:
+    post:
+      tags:
+        - oauth2
+      security:
+        - TrapMemberAuth: []
+      operationId: postLogout
+      responses:
+        "200":
+          description: |
+            ログアウトに成功した場合に返されます。
+            セッションが削除されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            セッションになんらかの誤りがあり、
+            認証に失敗した場合に返されます。
+            誤りの内容はレスポンスのmessageに出力されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: traP Collectionの管理画面からのログアウト
+      description: traP Collectionのログアウト
+
+  /users/me:
+    get:
+      tags:
+        - user
+      summary: 自分の情報の取得
+      description: 自分の情報の取得
+      security:
+        - TrapMemberAuth: []
+      operationId: getMe
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: |
+            自分の情報の取得に成功した際に返されます。
+            レスポンスでログインしているユーザーの情報が返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /users:
+    get:
+      tags:
+        - user
+      summary: traQの全ユーザー取得
+      description: traQの全ユーザー取得
+      security:
+        - TrapMemberAuth: []
+      operationId: getUsers
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  responses:
+    TraPUnauthorized:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        traQのOAuth 2.0での認証がされていない、
+        もしくは認証したが既にセッションが切れている場合に返されます。
+    InternalServerError:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: |
+        何らかの予期しないエラーが発生した場合に返されます。
+        このレスポンスが返された場合、サーバーのバグやインフラの障害の可能性が高いです。
+  securitySchemes:
+    TrapMemberAuth:
+      type: apiKey
+      in: cookie
+      name: sessions
+      description: |
+        traQのOAuth 2.0を利用してのログインをすでにしている場合のみアクセスできます。
+        ユーザーがtraQで凍結された場合、1日以内に反映されます。
+    GameMaintainerAuth:
+      type: apiKey
+      in: cookie
+      name: sessions
+      description: |
+        ゲームのmaintainer以上の権限を持っている、
+        またはtraP Collectionの管理者である場合のみアクセスできます。
+        ユーザーがtraQで凍結された場合、1日以内に反映されます。
+    GameOwnerAuth:
+      type: apiKey
+      in: cookie
+      name: sessions
+      description: |
+        ゲームのowner以上の権限を持っている、
+        またはtraP Collectionの管理者である場合のみアクセスできます。
+        ユーザーがtraQで凍結された場合、1日以内に反映されます。
+    AdminAuth:
+      type: apiKey
+      in: cookie
+      name: sessions
+      description: |
+        traP Collectionの管理者である場合のみアクセスできます。
+        ユーザーがtraQで凍結された場合、1日以内に反映されます。
+    LauncherAuth:
+      type: http
+      scheme: bearer
+      description: |
+        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        プロダクトキーがrevokeされた場合、即座に反映されます。
+  parameters:
+    authorizationCodeInQuery:
+      name: code
+      in: query
+      required: true
+      schema:
+        type: string
+      description: |
+        OAuth 2.0のAuthorization Codeです。
+    operatingSystemInQuery:
+      name: operatingSystem
+      in: query
+      required: true
+      schema:
+        $ref: '#/components/schemas/OperatingSystem'
+      description: |
+        OSの種類を示すクエリパラメータです。
+    launcherVersionIDInPath:
+      name: launcherVersionID
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: |
+        ランチャーのバージョンのIDを示すパスパラメータです。
+    gameIDInPath:
+      name: gameID
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: |
+        ゲームのIDを示すパスパラメータです。
+    gameVersionIDInPath:
+      name: gameVersionID
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: |
+        ゲームのバージョンのIDを示すパスパラメータです。
+    productKeyIDInPath:
+      name: productKeyID
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: |
+        ランチャーのプロダクトキーのIDを示すパスパラメータです。
+    seatIDInPath:
+      name: seatID
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: |
+        席のIDを示すパスパラメータです。
+  schemas:
+    Error:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Internal Server Error
+    OperatingSystem:
+      type: string
+      enum:
+        - win32
+        - darwin
+    User:
+      description: ユーザー
+      type: object
+      properties:
+        id:
+          description: traQのID（UUID）
+          type: string
+          format: uuid
+        name:
+          description: traQID（UUIDでない方）
+          type: string
+          example: mazrean
+      required:
+        - id
+        - name

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -106,14 +106,14 @@ paths:
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: traP Collectionの管理画面からのログアウト
-      description: traP Collectionのログアウト
+      description: |
+        traP Collectionの管理画面からログアウトします。
+        成功するとセッションが削除されます。
 
   /users/me:
     get:
       tags:
         - user
-      summary: 自分の情報の取得
-      description: 自分の情報の取得
       security:
         - TrapMemberAuth: []
       operationId: getMe
@@ -130,12 +130,13 @@ paths:
           $ref: '#/components/responses/TraPUnauthorized'
         "500":
           $ref: '#/components/responses/InternalServerError'
+      summary: ログイン中ユーザーの情報の取得
+      description: |
+        ログイン中のユーザーの情報を取得します。
   /users:
     get:
       tags:
         - user
-      summary: traQの全ユーザー取得
-      description: traQの全ユーザー取得
       security:
         - TrapMemberAuth: []
       operationId: getUsers
@@ -152,6 +153,176 @@ paths:
           $ref: '#/components/responses/TraPUnauthorized'
         "500":
           $ref: '#/components/responses/InternalServerError'
+      summary: traPのメンバー一覧取得
+      description: |
+        traPのアクティブメンバーの一覧を取得します。
+
+  /games:
+    post:
+      tags:
+        - game
+      security:
+        - TrapMemberAuth: []
+      operationId: postGame
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewGame'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameWithLatestVersion'
+          description: |
+            ゲームの追加に成功した際に返されます。
+            レスポンスで新しく追加されたゲームの情報が返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームの追加
+      description: |
+        新しくゲームを追加します。
+        このエンドポイントを叩いたユーザーは
+        自動的にownerとなります。
+    get:
+      tags:
+        - game
+      security:
+        - TrapMemberAuth: []
+      parameters:
+        - name: all
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: |
+            trueを指定すると、全てのゲーム、
+            falseを指定すると、ログイン中のユーザーが作成したゲームのみを返します。
+            デフォルトはtrueです。
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          description: |
+            取得するゲームの上限数を指定します。
+            指定なしの場合は制限なしです。
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+          description: |
+            取得するゲームの開始位置を指定します。
+            指定なしの場合は0となります。
+      operationId: getGames
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetGamesResponse'
+          description: |
+            ゲームの一覧の取得に成功した際に返されます。
+            レスポンスで取得したゲームの一覧と条件を満たすゲームの数が返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲーム一覧の取得
+      description: |
+        ゲームの一覧を取得します。
+  /games/{gameID}:
+    parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
+    get:
+      tags:
+        - game
+      security:
+        - TrapMemberAuth: []
+        - LauncherAuth: []
+      operationId: getGame
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Game'
+          description: |
+            ゲームの情報の取得に成功した際に返されます。
+            レスポンスで取得したゲームの情報が返されます。
+        "400":
+          description: |
+            ゲームIDが不正な値である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲーム情報の取得
+      description: |
+        指定したゲームIDのゲームの情報を取得します。
+    patch:
+      tags:
+        - game
+      security:
+        - TrapMemberAuth: []
+        - GameMaintainerAuth: []
+      operationId: putGame
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchGame'
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Game'
+        "400":
+          description: |
+            ゲームID、またはリクエストが不正である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームの情報の修正
+      description: |
+        指定したゲームIDのゲームの情報を修正します。
+    delete:
+      tags:
+        - game
+      security:
+        - GameOwnerAuth: []
+      operationId: deleteGames
+      responses:
+        "200":
+          description: 成功
+        "400":
+          description: |
+            ゲームIDが不正な値である場合に返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "404":
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームの削除
+      description: |
+        指定したゲームIDのゲームを削除します。
 
 components:
   responses:
@@ -281,18 +452,223 @@ components:
       enum:
         - win32
         - darwin
+    GetGamesResponse:
+      type: object
+      properties:
+        num:
+          type: integer
+          description: |
+            取得したゲームの数です。
+        games:
+          type: array
+          items:
+            $ref: '#/components/schemas/Game'
+          description: |
+            ゲームの一覧です。
+
+    # エンティティ
+    # ユーザー
     User:
       description: ユーザー
       type: object
       properties:
         id:
-          description: traQのID（UUID）
-          type: string
-          format: uuid
+          $ref: '#/components/schemas/UserID'
         name:
-          description: traQID（UUIDでない方）
-          type: string
-          example: mazrean
+          $ref: '#/components/schemas/UserName'
       required:
         - id
         - name
+
+    # ゲーム
+    NewGame:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/GameName'
+        description:
+          $ref: '#/components/schemas/GameDescription'
+        owners:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserName'
+          description: |
+            ゲームのownerの一覧です。
+            指定されない場合、空配列として扱われます。
+            ゲームの作成を実行したユーザーは、このリストに含まれていなくてもownerとなります。
+            また、このリストにゲームの作成を実行したユーザーが含まれていた場合も、
+            エラーにはならず、ゲームの作成を実行したユーザーが含まれない場合と同様の挙動をします。
+        maintainers:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserName'
+          description: |
+            ゲームのmaintainerの一覧です。
+            指定されない場合、空配列として扱われます。
+            ゲームの作成を実行したユーザーを含むownerと重複するユーザーが存在した場合、
+            400エラーとなります。
+        version:
+          $ref: '#/components/schemas/NewGameVersion'
+      required:
+        - name
+        - description
+        - version
+      description: |
+        ゲームを新しく作成する際に必要な情報です。
+    PatchGame:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/GameName'
+        description:
+          $ref: '#/components/schemas/GameDescription'
+      description: |
+        ゲームの情報を修正する際に必要な情報です。
+    Game:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/GameID'
+        name:
+          $ref: '#/components/schemas/GameName'
+        description:
+          $ref: '#/components/schemas/GameDescription'
+        owners:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserName'
+          description: |
+            ゲームのownerの一覧です。
+        maintainers:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserName'
+          description: |
+            ゲームのmaintainerの一覧です。
+            maintainerがいない場合、このフィールドは存在しません。
+        createdAt:
+          $ref: '#/components/schemas/GameCreatedAt'
+      required:
+        - id
+        - name
+        - description
+        - owners
+        - createdAt
+      description: |
+        ゲームの情報です。
+    GameWithLatestVersion:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Game'
+        - type: object
+          properties:
+            latestVersion:
+              $ref: '#/components/schemas/GameVersion'
+          required:
+            - latestVersion
+          description: |
+            ゲームとその最新バージョンの情報です。
+            ゲームの作成時のレスポンスのみで使用します。
+
+    # ゲームバージョン
+    NewGameVersion:
+      description: 新しいゲームのバージョン
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/GameVersionName'
+        description:
+          $ref: '#/components/schemas/GameVersionDescription'
+      required:
+        - name
+        - description
+    GameVersion:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/GameVersionID'
+        name:
+          $ref: '#/components/schemas/GameVersionName'
+        description:
+          $ref: '#/components/schemas/GameVersionDescription'
+        createdAt:
+          $ref: '#/components/schemas/GameVersionCreatedAt'
+      required:
+        - id
+        - name
+        - description
+        - createdAt
+
+    # 値オブジェクト
+    # ユーザー
+    UserID:
+      type: string
+      format: uuid
+      description: |
+        ユーザーのIDです。
+        traQのユーザーのUUIDと対応します。
+    UserName:
+      type: string
+      example: mazrean
+      description: |
+        ユーザー名です。
+        traQのユーザーのUUIDでないmazreanなどのIDと対応します。
+
+    # ゲーム
+    GameID:
+      type: string
+      format: uuid
+      description: |
+        ゲームのIDです。
+    GameName:
+      type: string
+      minLength: 1
+      maxLength: 256
+      example: 'PrestoRay'
+      description: |
+        ゲームの名前です。
+    GameDescription:
+      type: string
+      minLength: 0
+      maxLength: 1000
+      example: |
+        光を操作して進む、3Dのレースゲームです。
+        光は超高速ですが、その分制御するのが非常に難しくなっています。
+        コースを3周する時間を競うタイムアタックモードには、オンラインランキングを搭載。
+      description: |
+        ゲームの説明です。
+        ゲームのランチャーでも表示されます。
+    GameCreatedAt:
+      type: string
+      format: date-time
+      description: |
+        ゲームがtraP Collectionに追加された時刻です。
+
+    # ゲームバージョン
+    GameVersionID:
+      type: string
+      format: uuid
+      description: |
+        ゲームのバージョンのIDです。
+    GameVersionName:
+      type: string
+      pattern: ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      example: 'v1.0.0'
+      description: |
+        ゲームのバージョン名です。
+        セマンティックバージョニングに沿った文字列が許容されます。
+    GameVersionDescription:
+      type: string
+      minLength: 0
+      maxLength: 500
+      example: |
+        - 新機能1の追加
+        - 新機能2の追加
+      description: |
+        ゲームのバージョンの説明です。
+        主にゲームの開発者向けの情報で、ランチャーでは表示されません。
+    GameVersionCreatedAt:
+      type: string
+      format: date-time
+      description: |
+        ゲームのバージョンが作成された時刻です。

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -112,7 +112,7 @@ paths:
         - TrapMemberAuth: []
       operationId: postLogout
       responses:
-        "200":
+        "204":
           description: |
             ログアウトに成功した場合に返されます。
             セッションが削除されます。
@@ -2105,6 +2105,7 @@ components:
           example: Internal Server Error
       required:
         - message
+      additionalProperties: false
     UserRequest:
       type: object
       properties:
@@ -2114,6 +2115,7 @@ components:
         - id
       description: |
         ユーザーを指定するリクエストです。
+      additionalProperties: false
     GetGamesResponse:
       type: object
       properties:
@@ -2130,6 +2132,7 @@ components:
       required:
         - num
         - games
+      additionalProperties: false
       description: |
         ゲームの一覧を取得します。
         ページングのために、limit、offsetを適用する前のゲームの数をnumで返しています。
@@ -2142,6 +2145,7 @@ components:
           $ref: '#/components/schemas/GameRoleType'
       required:
         - id
+      additionalProperties: false
       description: |
         ゲームのロールを指定するリクエストです。
     GetGameVersionsResponse:
@@ -2160,6 +2164,7 @@ components:
       required:
         - num
         - versions
+      additionalProperties: false
       description: |
         ゲームバージョンの一覧を取得します。
         ページングのために、limit、offsetを適用する前のゲームバージョンの数もnumで返しています。
@@ -2172,6 +2177,7 @@ components:
             $ref: '#/components/schemas/GameVersionID'
       required:
         - gameVersionIDs
+      additionalProperties: false
       description: |
         エディションのゲームを変更するためのリクエストです。
     EditionGameResponse:
@@ -2184,6 +2190,7 @@ components:
               $ref: '#/components/schemas/GameVersion'
           required:
             - version
+          additionalProperties: false
       description: |
         エディションに紐づけられた
         ゲームとバージョンの情報です。
@@ -2194,6 +2201,7 @@ components:
           $ref: '#/components/schemas/ProductKeyValue'
       required:
         - key
+      additionalProperties: false
       description: |
         ランチャーのエディション情報取得認可のリクエストです。
     PostSeatRequest:
@@ -2206,6 +2214,7 @@ components:
             席数です。
       required:
         - num
+      additionalProperties: false
       description: |
         席数を変更するためのリクエストです。
     PatchSeatStatusRequest:
@@ -2215,6 +2224,7 @@ components:
           $ref: '#/components/schemas/SeatStatus'
       required:
         - status
+      additionalProperties: false
       description: |
         席の着席状態を変更するためのリクエストです。
 
@@ -2231,6 +2241,7 @@ components:
       required:
         - id
         - name
+      additionalProperties: false
 
     # ゲーム
     NewGame:
@@ -2262,6 +2273,7 @@ components:
       required:
         - name
         - description
+      additionalProperties: false
       description: |
         ゲームを新しく作成する際に必要な情報です。
     PatchGame:
@@ -2274,6 +2286,7 @@ components:
       required:
         - name
         - description
+      additionalProperties: false
       description: |
         ゲームの情報を修正する際に必要な情報です。
     Game:
@@ -2306,6 +2319,7 @@ components:
         - description
         - owners
         - createdAt
+      additionalProperties: false
       description: |
         ゲームの情報です。
     GameInfo:
@@ -2324,6 +2338,7 @@ components:
         - name
         - description
         - createdAt
+      additionalProperties: false
       description: |
         ゲームの情報です。
 
@@ -2348,6 +2363,7 @@ components:
         - description
         - imageID
         - videoID
+      additionalProperties: false
       description: |
         新しいゲームのバージョンの作成に必要な情報です。
         url、filesはゲームの種類に応じていずれかが存在します。
@@ -2377,6 +2393,7 @@ components:
         - imageID
         - videoID
         - createdAt
+      additionalProperties: false
       description: |
         ゲームのバージョンです。
         url、filesはゲームの種類に応じていずれかが存在します。
@@ -2389,6 +2406,7 @@ components:
           $ref: '#/components/schemas/GameFileID'
         jar:
           $ref: '#/components/schemas/GameFileID'
+      additionalProperties: false
       description: |
         ゲームバージョンに紐づいたファイルの情報です。
 
@@ -2406,6 +2424,7 @@ components:
         - type
         - entryPoint
         - content
+      additionalProperties: false
       description: |
         ゲームのファイルを新しく作成する際に必要な情報です。
     GameFile:
@@ -2427,6 +2446,7 @@ components:
         - md5
         - entryPoint
         - createdAt
+      additionalProperties: false
       description: |
         ゲームのファイルのメタ情報です。
 
@@ -2441,6 +2461,7 @@ components:
       required:
         - type
         - content
+      additionalProperties: false
       description: |
         ゲームの画像を新しく作成する際に必要な情報です。
     GameImage:
@@ -2456,6 +2477,7 @@ components:
         - id
         - type
         - createdAt
+      additionalProperties: false
       description: |
         ゲームの画像のメタ情報です。
 
@@ -2470,6 +2492,7 @@ components:
       required:
         - type
         - content
+      additionalProperties: false
       description: |
         ゲームの動画を新しく作成する際に必要な情報です。
     GameVideo:
@@ -2485,6 +2508,7 @@ components:
         - id
         - type
         - createdAt
+      additionalProperties: false
       description: |
         ゲームの動画のメタ情報です。
 
@@ -2499,6 +2523,7 @@ components:
       required:
         - name
         - questionnaire
+      additionalProperties: false
       description: |
         エディションの情報を修正する際に必要な情報です。
     NewEdition:
@@ -2514,6 +2539,7 @@ components:
             $ref: '#/components/schemas/GameVersionID'
       required:
         - name
+      additionalProperties: false
       description: |
         エディションを新しく作成する際に必要な情報です。
         questionnaireは工大祭などのアンケートが必要な際のみ存在します。
@@ -2532,6 +2558,7 @@ components:
         - id
         - name
         - createdAt
+      additionalProperties: false
       description: |
         エディションです。
         questionnaireは工大祭などのアンケートが必要な際のみ存在します。
@@ -2553,6 +2580,7 @@ components:
         - key
         - status
         - createdAt
+      additionalProperties: false
     EditionAccessToken:
       type: object
       properties:
@@ -2563,6 +2591,7 @@ components:
       required:
         - accessToken
         - expiresAt
+      additionalProperties: false
 
     # 席
     Seat:
@@ -2575,6 +2604,7 @@ components:
       required:
         - id
         - status
+      additionalProperties: false
       description: |
         席の情報です。
 
@@ -2589,6 +2619,7 @@ components:
     UserName:
       type: string
       example: mazrean
+      maxLength: 32
       description: |
         ユーザー名です。
         traQのユーザーのUUIDでないmazreanなどのIDと対応します。

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -38,12 +38,12 @@ tags:
   - name: gameVideo
     description: |
       ゲームのビデオ関連のAPIです。
-  - name: launcherVersion
+  - name: edition
     description: |
-      ランチャーのバージョン関連のAPIです。
-  - name: launcherAuth
+      エディション(旧ランチャーバージョン)関連のAPIです。
+  - name: editionAuth
     description: |
-      ランチャーの認可関連のAPIです。
+      ランチャーからのエディション情報取得の認可関連のAPIです。
   - name: seat
     description: |
       席管理関連のAPIです。
@@ -341,7 +341,7 @@ paths:
         - game
       security:
         - TrapMemberAuth: []
-        - LauncherGameAuth: []
+        - EditionGameAuth: []
       operationId: getGame
       responses:
         "200":
@@ -366,7 +366,7 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             traQのOAuth 2.0による認証が通過できない、かつ、
-            ランチャーのアクセストークンによるBearer認証も通過できない場合に返されます。
+            ランチャー用のアクセストークンによるBearer認証も通過できない場合に返されます。
         "404":
           content:
             application/json:
@@ -723,7 +723,7 @@ paths:
         - gameFile
       security:
         - TrapMemberAuth: []
-        - LauncherGameFileAuth: []
+        - EditionGameFileAuth: []
       operationId: getGameFile
       responses:
         "200":
@@ -748,7 +748,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             traQのOAuth 2.0認証を通過できず、かつ、
-            ランチャーの認証を通過できないまたはランチャーにこのファイルに対応するゲームバージョンが含まれない場合に返されます。
+            ランチャー用のアクセストークンによるBearer認証を通過できない、
+            または、アクセストークンに対応するエディションにこのファイルに対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -769,7 +770,7 @@ paths:
         - gameFile
       security:
         - TrapMemberAuth: []
-        - LauncherGameFileAuth: []
+        - EditionGameFileAuth: []
       operationId: getGameFileMeta
       responses:
         "200":
@@ -794,7 +795,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             traQのOAuth 2.0認証を通過できず、かつ、
-            ランチャーの認証を通過できないまたはランチャーにこのファイルに対応するゲームバージョンが含まれない場合に返されます。
+            ランチャー用のアクセストークンによるBearer認証を通過できない、
+            または、アクセストークンに対応するエディションにこのファイルに対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -860,7 +862,7 @@ paths:
         - gameImage
       security:
         - TrapMemberAuth: []
-        - LauncherGameImageAuth: []
+        - EditionGameImageAuth: []
       operationId: getGameImage
       responses:
         "200":
@@ -885,7 +887,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             traQのOAuth 2.0認証を通過できず、かつ、
-            ランチャーの認証を通過できないまたはランチャーにこの画像に対応するゲームバージョンが含まれない場合に返されます。
+            ランチャー用のアクセストークンによるBearer認証を通過できない、
+            または、アクセストークンに対応するエディションにこの画像に対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -906,7 +909,7 @@ paths:
         - gameImage
       security:
         - TrapMemberAuth: []
-        - LauncherGameImageAuth: []
+        - EditionGameImageAuth: []
       operationId: getGameImageMeta
       responses:
         "200":
@@ -931,7 +934,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             traQのOAuth 2.0認証を通過できず、かつ、
-            ランチャーの認証を通過できないまたはランチャーにこの画像に対応するゲームバージョンが含まれない場合に返されます。
+            ランチャー用のアクセストークンによるBearer認証を通過できない、
+            または、アクセストークンに対応するエディションにこの画像に対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -997,7 +1001,7 @@ paths:
         - gameVideo
       security:
         - TrapMemberAuth: []
-        - LauncherGameVideoAuth: []
+        - EditionGameVideoAuth: []
       operationId: getGameVideo
       responses:
         "200":
@@ -1022,7 +1026,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             traQのOAuth 2.0認証を通過できず、かつ、
-            ランチャーの認証を通過できないまたはランチャーにこの動画に対応するゲームバージョンが含まれない場合に返されます。
+            ランチャー用のアクセストークンによるBearer認証を通過できない、
+            またはアクセストークンに対応するエディションにこの動画に対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -1043,7 +1048,7 @@ paths:
         - gameVideo
       security:
         - TrapMemberAuth: []
-        - LauncherGameVideoAuth: []
+        - EditionGameVideoAuth: []
       operationId: getGameVideoMeta
       responses:
         "200":
@@ -1068,7 +1073,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: |
             traQのOAuth 2.0認証を通過できず、かつ、
-            ランチャーの認証を通過できないまたはランチャーにこの動画に対応するゲームバージョンが含まれない場合に返されます。
+            ランチャー用のアクセストークンによるBearer認証を通過できない、
+            または、アクセストークンに対応するエディションにこの動画に対応するゲームバージョンが含まれない場合に返されます。
         "404":
           content:
             application/json:
@@ -1082,28 +1088,28 @@ paths:
       description: |
         指定したゲーム動画IDのゲーム動画のメタ情報を取得します。
 
-  # launcherVersion
-  /launchers:
+  # edition
+  /editions:
     post:
       tags:
-        - launcherVersion
+        - edition
       security:
         - AdminAuth: []
-      operationId: postLauncherVersion
+      operationId: postEdition
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewLauncherVersion'
+              $ref: '#/components/schemas/NewEdition'
       responses:
         "201":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LauncherVersion'
+                $ref: '#/components/schemas/Edition'
           description: |
-            ランチャーのバージョンの作成に成功した際に返されます。
-            レスポンスで作成したランチャーのバージョンのメタ情報が返されます。
+            エディションの作成に成功した際に返されます。
+            レスポンスで作成したエディションのメタ情報が返されます。
         "400":
           content:
             application/json:
@@ -1117,15 +1123,15 @@ paths:
           $ref: '#/components/responses/AdminForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのバージョンの作成
+      summary: エディションの作成
       description: |
-        ランチャーのバージョンを作成します。
+        エディションを作成します。
     get:
       tags:
-        - launcherVersion
+        - edition
       security:
         - TrapMemberAuth: []
-      operationId: getLauncherVersions
+      operationId: getEditions
       responses:
         "200":
           content:
@@ -1133,10 +1139,10 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/LauncherVersion'
+                  $ref: '#/components/schemas/Edition'
           description: |
-            ランチャーのバージョンの取得に成功した際に返されます。
-            レスポンスで取得したランチャーのバージョンのリストが返されます。
+            エディションの取得に成功した際に返されます。
+            レスポンスで取得したエディションのリストが返されます。
         "400":
           content:
             application/json:
@@ -1148,27 +1154,27 @@ paths:
           $ref: '#/components/responses/TraPUnauthorized'
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのバージョン一覧の取得
+      summary: エディション一覧の取得
       description: |
-        ランチャーのバージョンの一覧を取得します。
-  /launchers/{launcherVersionID}:
+        エディションの一覧を取得します。
+  /editions/{editionID}:
     parameters:
-      - $ref: '#/components/parameters/launcherVersionIDInPath'
+      - $ref: '#/components/parameters/editionIDInPath'
     get:
       tags:
-        - launcherVersion
+        - edition
       security:
         - TrapMemberAuth: []
-      operationId: getLauncherVersion
+      operationId: getEdition
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LauncherVersion'
+                $ref: '#/components/schemas/Edition'
           description: |
-            ランチャーのバージョンの取得に成功した際に返されます。
-            レスポンスで取得したランチャーのバージョンのメタ情報が返されます。
+            エディションの取得に成功した際に返されます。
+            レスポンスで取得したエディションのメタ情報が返されます。
         "400":
           content:
             application/json:
@@ -1184,32 +1190,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: |
-            指定したIDのランチャーのバージョンが存在しない、または削除されている場合に返されます。
+            指定したIDのエディションが存在しない、または削除されている場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのバージョン情報の取得
+      summary: エディション情報の取得
       description: |
-        指定したランチャーのバージョンIDのランチャーのバージョンのメタ情報を取得します。
+        指定したeditionIDのエディションのメタ情報を取得します。
     patch:
       tags:
-        - launcherVersion
+        - edition
       security:
         - AdminAuth: []
-      operationId: patchLauncherVersion
+      operationId: patchEdition
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchLauncherVersion'
+              $ref: '#/components/schemas/PatchEdition'
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LauncherVersion'
+                $ref: '#/components/schemas/Edition'
           description: |
-            ランチャーのバージョンの変更に成功した際に返されます。
-            レスポンスで変更したランチャーのバージョンのメタ情報が返されます。
+            エディションの変更に成功した際に返されます。
+            レスポンスで変更したエディションのメタ情報が返されます。
         "400":
           content:
             application/json:
@@ -1227,22 +1233,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: |
-            指定したIDのランチャーのバージョンが存在しない、または削除されている場合に返されます。
+            指定したIDのエディションが存在しない、または削除されている場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのバージョン情報の変更
+      summary: エディション情報の変更
       description: |
-        指定したランチャーのバージョンIDのランチャーのバージョンの情報を変更します。
+        指定したeditionIDのエディションの情報を変更します。
     delete:
       tags:
-        - launcherVersion
+        - edition
       security:
         - AdminAuth: []
-      operationId: deleteLauncherVersion
+      operationId: deleteEdition
       responses:
         "200":
           description: |
-            ランチャーのバージョンの削除に成功した際に返されます。
+            エディションの削除に成功した際に返されます。
         "400":
           content:
             application/json:
@@ -1260,26 +1266,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: |
-            指定したIDのランチャーのバージョンが存在しない、または削除されている場合に返されます。
+            指定したIDのエディションが存在しない、または削除されている場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのバージョンの削除
+      summary: エディションの削除
       description: |
-        指定したランチャーのバージョンを削除します。
-  /launchers/{launcherVersionID}/games:
+        指定したエディションを削除します。
+  /editions/{editionID}/games:
     parameters:
-      - $ref: '#/components/parameters/launcherVersionIDInPath'
+      - $ref: '#/components/parameters/editionIDInPath'
     patch:
       tags:
-        - launcherVersion
+        - edition
       security:
         - AdminAuth: []
-      operationId: postLauncherVersionGame
+      operationId: postEditionGame
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchLauncherVersionGameRequest'
+              $ref: '#/components/schemas/PatchEditionGameRequest'
       responses:
         "200":
           content:
@@ -1287,10 +1293,10 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/LauncherVersionGameResponse'
+                  $ref: '#/components/schemas/EditionGameResponse'
           description: |
-            ランチャーのバージョンのゲームの変更に成功した際に返されます。
-            レスポンスで変更後のランチャーのバージョンに紐づいたゲームとゲームバージョン一覧が返されます。
+            エディションのゲームの変更に成功した際に返されます。
+            レスポンスで変更後のエディションに紐づいたゲームとゲームバージョン一覧が返されます。
         "400":
           content:
             application/json:
@@ -1304,16 +1310,16 @@ paths:
           $ref: '#/components/responses/AdminForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーバージョンのゲームの変更
+      summary: エディションのゲームの変更
       description: |
-        ランチャーバージョンにゲームを追加します。
+        エディションにゲームを追加します。
     get:
       tags:
-        - launcherVersion
+        - edition
       security:
         - TrapMemberAuth: []
-        - LauncherIDAuth: []
-      operationId: getLauncherVersionGames
+        - EditionIDAuth: []
+      operationId: getEditionGames
       responses:
         "200":
           content:
@@ -1321,9 +1327,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/LauncherVersionGameResponse'
+                  $ref: '#/components/schemas/EditionGameResponse'
           description: |
-            ランチャーのバージョンに紐づくゲームとバージョンの一覧の取得に成功した際に返されます。
+            エディションに紐づくゲームとバージョンの一覧の取得に成功した際に返されます。
             レスポンスで取得したゲームとバージョンのリストが返されます。
         "400":
           content:
@@ -1340,27 +1346,27 @@ paths:
           description: |
             traQのOAuth 2.0認証を通過できない、かつ、
             ランチャーのアクセストークンによるBearer認証を通過できない、
-            または、アクセストークンに対応するランチャーバージョンとlauncherIDが一致しない場合に返されます。
+            または、アクセストークンに対応するエディションとeditionIDが一致しない場合に返されます。
         "404":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
           description: |
-            指定したIDのランチャーのバージョンが存在しない、または削除されている場合に返されます。
+            指定したIDのエディションが存在しない、または削除されている場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのバージョンに紐づくゲームの一覧の取得
+      summary: エディションに紐づくゲームの一覧の取得
       description: |
-        ランチャーのバージョンに紐づくゲームの一覧を取得します。
+        エディションに紐づくゲームの一覧を取得します。
 
-  # launcherAuth
-  /launchers/{launcherVersionID}/keys:
+  # editionAuth
+  /editions/{editionID}/keys:
     parameters:
-      - $ref: '#/components/parameters/launcherVersionIDInPath'
+      - $ref: '#/components/parameters/editionIDInPath'
     post:
       tags:
-        - launcherAuth
+        - editionAuth
       security:
         - AdminAuth: []
       parameters:
@@ -1375,8 +1381,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/ProductKey'
           description: |
-            ランチャーのプロダクトキーの発行に成功した際に返されます。
-            レスポンスで発行したランチャーのプロダクトキーのリストが返されます。
+            プロダクトキーの発行に成功した際に返されます。
+            レスポンスで発行したプロダクトキーのリストが返されます。
         "400":
           content:
             application/json:
@@ -1390,12 +1396,12 @@ paths:
           $ref: '#/components/responses/AdminForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのプロダクトキーの生成
+      summary: プロダクトキーの生成
       description: |
-        ランチャーのバージョンに対するプロダクトキーを生成します。
+        ランチャーからのエディション情報取得の認可用プロダクトキーを生成します。
     get:
       tags:
-        - launcherAuth
+        - editionAuth
       security:
         - AdminAuth: []
       parameters:
@@ -1410,7 +1416,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/ProductKey'
           description: |
-            ランチャーのバージョンに紐づくプロダクトキーの取得に成功した際に返されます。
+            エディションに紐づくプロダクトキーの取得に成功した際に返されます。
             レスポンスで取得したプロダクトキーのリストが返されます。
         "400":
           content:
@@ -1425,16 +1431,16 @@ paths:
           $ref: '#/components/responses/AdminForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのプロダクトキーの一覧の取得
+      summary: プロダクトキーの一覧の取得
       description: |
-        ランチャーのバージョンに対するプロダクトキーの一覧を取得します。
-  /launchers/{launcherVersionID}/keys/{productKeyID}/activate:
+        エディションに対するプロダクトキーの一覧を取得します。
+  /editions/{editionID}/keys/{productKeyID}/activate:
     parameters:
-      - $ref: '#/components/parameters/launcherVersionIDInPath'
+      - $ref: '#/components/parameters/editionIDInPath'
       - $ref: '#/components/parameters/productKeyIDInPath'
     post:
       tags:
-        - launcherAuth
+        - editionAuth
       security:
         - AdminAuth: []
       operationId: postActivateProductKey
@@ -1467,16 +1473,16 @@ paths:
             指定したIDのプロダクトキーが存在しない、または既に有効な場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのプロダクトキーの再有効化
+      summary: プロダクトキーの再有効化
       description: |
-        ランチャーのバージョンに対するプロダクトキーを再有効化します。
-  /launchers/{launcherVersionID}/keys/{productKeyID}/revoke:
+        エディションに対するプロダクトキーを再有効化します。
+  /editions/{editionID}/keys/{productKeyID}/revoke:
     parameters:
-      - $ref: '#/components/parameters/launcherVersionIDInPath'
+      - $ref: '#/components/parameters/editionIDInPath'
       - $ref: '#/components/parameters/productKeyIDInPath'
     post:
       tags:
-        - launcherAuth
+        - editionAuth
       security:
         - AdminAuth: []
       operationId: postRevokeProductKey
@@ -1509,28 +1515,28 @@ paths:
             指定したIDのプロダクトキーが存在しない、または既に失効している場合に返されます。
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのプロダクトキーの失効
+      summary: プロダクトキーの失効
       description: |
-        ランチャーのバージョンに対するプロダクトキーを失効(revoke)します。
-  /launchers/authorize:
+        エディションに対するプロダクトキーを失効(revoke)します。
+  /editions/authorize:
     post:
       tags:
-        - launcherAuth
-      operationId: postLauncherAuthorize
+        - editionAuth
+      operationId: postEditionAuthorize
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LauncherAuthorizeRequest'
+              $ref: '#/components/schemas/EditionAuthorizeRequest'
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LauncherAccessToken'
+                $ref: '#/components/schemas/EditionAccessToken'
           description: |
-            ランチャーの認可に成功した際に返されます。
+            ランチャーのエディション情報取得の認可に成功した際に返されます。
             ランチャーのBearer認証に使用するトークンが返されます。
         "400":
           content:
@@ -1540,28 +1546,30 @@ paths:
           description: |
             リクエストが不正である場合に返されます。
         "403":
-          $ref: '#/components/responses/LauncherForbidden'
+          $ref: '#/components/responses/EditionForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: ランチャーの認可リクエスト
       description: |
-        ランチャーの認可リクエストを行います。
-        リクエストに成功すると、ランチャーのアクセストークンが返されます。
-        このアクセストークンを用いたBearer認証で、ランチャー用APIを利用することができます。
-  /launchers/info:
+        ランチャーのエディション情報取得の認可リクエストを行います。
+        リクエストに成功すると、アクセストークンが返されます。
+        このアクセストークンを用いたBearer認証で、エディション情報取得用のAPIを利用することができます。
+  /editions/info:
     get:
       tags:
-        - launcherAuth
-      operationId: getLauncherInfo
+        - editionAuth
+      operationId: getEditionInfo
       security:
-        - LauncherAuth: []
+        - EditionAuth: []
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LauncherVersion'
-          description: 成功
+                $ref: '#/components/schemas/Edition'
+          description: |
+            エディション情報取得に成功した際に返されます。
+            エディション情報が返されます。
         "400":
           content:
             application/json:
@@ -1570,12 +1578,12 @@ paths:
           description: |
             リクエストが不正である場合に返されます。
         "403":
-          $ref: '#/components/responses/LauncherForbidden'
+          $ref: '#/components/responses/EditionForbidden'
         "500":
           $ref: '#/components/responses/InternalServerError'
-      summary: ランチャーのバージョン情報の取得
+      summary: エディション情報の取得
       description: |
-        アクセストークンをもとにランチャーのバージョン情報を取得します。
+        アクセストークンをもとにエディションの情報を取得します。
 
   #seat
   /seats:
@@ -1696,7 +1704,7 @@ components:
             $ref: '#/components/schemas/Error'
       description: |
         adminでない場合に返されます。
-    LauncherForbidden:
+    EditionForbidden:
       content:
         application/json:
           schema:
@@ -1743,51 +1751,51 @@ components:
       description: |
         traP Collectionの管理者である場合のみアクセスできます。
         ユーザーがtraQで凍結された場合、1日以内に反映されます。
-    LauncherAuth:
+    EditionAuth:
       type: http
       scheme: bearer
       description: |
-        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        プロダクトキーを利用して得られるアクセストークンを利用した認証です。
         アクセストークンが正しく、有効期限が切れていない場合にのみアクセスできます。
         プロダクトキーがrevokeされた場合、即座に反映されます。
-    LauncherIDAuth:
+    EditionIDAuth:
       type: http
       scheme: bearer
       description: |
-        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        プロダクトキーを利用して得られるアクセストークンを利用した認証です。
         アクセストークンが正しく、有効期限が切れていないかつ、
-        launcherIDを対応するランチャーが一致する場合にのみアクセスできます。
+        editionIDを対応するエディションが一致する場合にのみアクセスできます。
         プロダクトキーがrevokeされた場合、即座に反映されます。
-    LauncherGameAuth:
+    EditionGameAuth:
       type: http
       scheme: bearer
       description: |
-        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
-        アクセストークンから得られるランチャーのバージョンに、
+        プロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        アクセストークンから得られるエディションに、
         ゲームIDで指定されたゲームが含まれる場合のみアクセスできます。
         プロダクトキーがrevokeされた場合、即座に反映されます。
-    LauncherGameFileAuth:
+    EditionGameFileAuth:
       type: http
       scheme: bearer
       description: |
-        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
-        アクセストークンから得られるランチャーのバージョンに、
+        プロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        アクセストークンから得られるエディションに、
         ファイルIDで指定されたファイルに対応するゲームが含まれる場合のみアクセスできます。
         プロダクトキーがrevokeされた場合、即座に反映されます。
-    LauncherGameImageAuth:
+    EditionGameImageAuth:
       type: http
       scheme: bearer
       description: |
-        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
-        アクセストークンから得られるランチャーのバージョンに、
+        プロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        アクセストークンから得られるエディションに、
         画像IDで指定された画像に対応するゲームが含まれる場合のみアクセスできます。
         プロダクトキーがrevokeされた場合、即座に反映されます。
-    LauncherGameVideoAuth:
+    EditionGameVideoAuth:
       type: http
       scheme: bearer
       description: |
-        ランチャーのプロダクトキーを利用して得られるアクセストークンを利用した認証です。
-        アクセストークンから得られるランチャーのバージョンに、
+        プロダクトキーを利用して得られるアクセストークンを利用した認証です。
+        アクセストークンから得られるエディションに、
         動画IDで指定された動画に対応するゲームが含まれる場合のみアクセスできます。
         プロダクトキーがrevokeされた場合、即座に反映されます。
   parameters:
@@ -1818,15 +1826,15 @@ components:
       description: |
         プロダクトキーのステータスを示すクエリパラメータです。
         指定がない場合は全てのステータスのプロダクトキーが返されます。
-    launcherVersionIDInPath:
-      name: launcherVersionID
+    editionIDInPath:
+      name: editionID
       in: path
       required: true
       schema:
         type: string
         format: uuid
       description: |
-        ランチャーのバージョンのIDを示すパスパラメータです。
+        エディションのIDを示すパスパラメータです。
     gameIDInPath:
       name: gameID
       in: path
@@ -1867,7 +1875,7 @@ components:
         type: string
         format: uuid
       description: |
-        ランチャーのプロダクトキーのIDを示すパスパラメータです。
+        プロダクトキーのIDを示すパスパラメータです。
     seatIDInPath:
       name: seatID
       in: path
@@ -1935,7 +1943,7 @@ components:
       description: |
         ゲームバージョンの一覧を取得します。
         ページングのために、limit、offsetを適用する前のゲームバージョンの数もnumで返しています。
-    PatchLauncherVersionGameRequest:
+    PatchEditionGameRequest:
       type: object
       properties:
         gameVersionIDs:
@@ -1945,8 +1953,8 @@ components:
       required:
         - gameVersionIDs
       description: |
-        ランチャーのバージョンのゲームを変更するためのリクエストです。
-    LauncherVersionGameResponse:
+        エディションのゲームを変更するためのリクエストです。
+    EditionGameResponse:
       type: object
       allOf:
         - $ref: '#/components/schemas/GameInfo'
@@ -1957,9 +1965,9 @@ components:
           required:
             - version
       description: |
-        ランチャーのバージョンに紐づけられた
+        エディションに紐づけられた
         ゲームとバージョンの情報です。
-    LauncherAuthorizeRequest:
+    EditionAuthorizeRequest:
       type: object
       properties:
         key:
@@ -1967,7 +1975,7 @@ components:
       required:
         - key
       description: |
-        ランチャーの認可のリクエストです。
+        ランチャーのエディション情報取得認可のリクエストです。
     PostSeatRequest:
       type: object
       properties:
@@ -2287,26 +2295,26 @@ components:
       description: |
         ゲームの動画のメタ情報です。
 
-    # ランチャーバージョン
-    PatchLauncherVersion:
+    # エディション
+    PatchEdition:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/LauncherVersionName'
+          $ref: '#/components/schemas/EditionName'
         questionnaire:
-          $ref: '#/components/schemas/LauncherVersionQuestionnaireURL'
+          $ref: '#/components/schemas/EditionQuestionnaireURL'
       required:
         - name
         - questionnaire
       description: |
-        ランチャーバージョンの情報を修正する際に必要な情報です。
-    NewLauncherVersion:
+        エディションの情報を修正する際に必要な情報です。
+    NewEdition:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/LauncherVersionName'
+          $ref: '#/components/schemas/EditionName'
         questionnaire:
-          $ref: '#/components/schemas/LauncherVersionQuestionnaireURL'
+          $ref: '#/components/schemas/EditionQuestionnaireURL'
         gameVersions:
           type: array
           items:
@@ -2314,28 +2322,28 @@ components:
       required:
         - name
       description: |
-        ランチャーのバージョンを新しく作成する際に必要な情報です。
+        エディションを新しく作成する際に必要な情報です。
         questionnaireは工大祭などのアンケートが必要な際のみ存在します。
-    LauncherVersion:
+    Edition:
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/LauncherVersionID'
+          $ref: '#/components/schemas/EditionID'
         name:
-          $ref: '#/components/schemas/LauncherVersionName'
+          $ref: '#/components/schemas/EditionName'
         questionnaire:
-          $ref: '#/components/schemas/LauncherVersionQuestionnaireURL'
+          $ref: '#/components/schemas/EditionQuestionnaireURL'
         createdAt:
-          $ref: '#/components/schemas/LauncherVersionCreatedAt'
+          $ref: '#/components/schemas/EditionCreatedAt'
       required:
         - id
         - name
         - createdAt
       description: |
-        ランチャーのバージョンです。
+        エディションです。
         questionnaireは工大祭などのアンケートが必要な際のみ存在します。
 
-    # ランチャーの認証
+    # ランチャーのエディション情報取得の認可
     ProductKey:
       type: object
       properties:
@@ -2349,13 +2357,13 @@ components:
         - id
         - key
         - status
-    LauncherAccessToken:
+    EditionAccessToken:
       type: object
       properties:
         accessToken:
-          $ref: '#/components/schemas/LauncherAccessTokenValue'
+          $ref: '#/components/schemas/EditionAccessTokenValue'
         expiresAt:
-          $ref: '#/components/schemas/LauncherAccessTokenExpiresAt'
+          $ref: '#/components/schemas/EditionAccessTokenExpiresAt'
       required:
         - accessToken
         - expiresAt
@@ -2412,7 +2420,7 @@ components:
         コースを3周する時間を競うタイムアタックモードには、オンラインランキングを搭載。
       description: |
         ゲームの説明です。
-        ゲームのランチャーでも表示されます。
+        ランチャーでも表示されます。
     GameCreatedAt:
       type: string
       format: date-time
@@ -2542,60 +2550,60 @@ components:
       description: |
         ゲーム紹介動画の作成時刻です。
 
-    # ランチャーバージョン
-    LauncherVersionID:
+    # エディション
+    EditionID:
       type: string
       format: uuid
       description: |
-        ランチャーのバージョンのIDです。
-    LauncherVersionName:
+        エディションのIDです。
+    EditionName:
       type: string
       maxLength: 32
       description: |
-        ランチャーのバージョン名です。
-    LauncherVersionQuestionnaireURL:
+        エディション名です。
+    EditionQuestionnaireURL:
       type: string
       format: uri
       description: |
-        ランチャーのバージョンのアンケートのURLです。
-    LauncherVersionCreatedAt:
+        エディションのアンケートのURLです。
+    EditionCreatedAt:
       type: string
       format: date-time
       description: |
-        ランチャーのバージョンが作成された時刻です。
+        エディションが作成された時刻です。
 
-    # ランチャーの認証
+    # ランチャーのエディション情報取得の認可
     ProductKeyID:
       type: string
       format: uuid
       description: |
-        ランチャーのプロダクトキーのIDです。
+        プロダクトキーのIDです。
     ProductKeyValue:
       type: string
       pattern: '^[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}-[0-9a-zA-Z]{5}'
       example: 12345-ABCDE-67890-FGHIJ-KLMNO
       description: |
-        ランチャーのプロダクトキーの値です。
+        プロダクトキーの値です。
         暗号的にランダムな英数字5文字をハイフン区切りで5つ並べたものです。
     ProductKeyStatus:
       type: string
       enum:
         - active
         - revoked
-    LauncherAccessTokenValue:
+    EditionAccessTokenValue:
       type: string
       maxLength: 36
       minLength: 36
       pattern: '[0-9a-zA-Z]{36}'
       example: 1234567890abcdef1234567890abcdef1234
       description: |
-        ランチャーのアクセストークンです。
+        アクセストークンです。
         暗号的にランダムな英数字36文字です。
-    LauncherAccessTokenExpiresAt:
+    EditionAccessTokenExpiresAt:
       type: string
       format: date-time
       description: |
-        ランチャーのアクセストークンの有効期限です。
+        アクセストークンの有効期限です。
 
     # 席
     SeatID:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -12,18 +12,44 @@ info:
     url: 'https://github.com/traPtitech/trap-collection-server'
 tags:
   - name: oauth2
+    description: |
+      OAuth 2.0を利用しての管理画面の認証を行うAPIです。
   - name: user
+    description: |
+      管理画面のユーザー関連のAPIです。
   - name: admin
+    description: |
+      traP Collection全体の管理者関連のAPIです。
   - name: game
+    description: |
+      ゲーム関連のAPIです。
   - name: gameRole
+    description: |
+      ゲームの操作権限関連のAPIです。
   - name: gameVersion
+    description: |
+      ゲームのバージョン関連のAPIです。
   - name: gameFile
+    description: |
+      ゲームのファイル関連のAPIです。
   - name: gameURL
+    description: |
+      ゲームのURL関連のAPIです。
   - name: gameImage
+    description: |
+      ゲームの画像関連のAPIです。
   - name: gameVideo
+    description: |
+      ゲームのビデオ関連のAPIです。
   - name: launcherVersion
+    description: |
+      ランチャーのバージョン関連のAPIです。
   - name: launcherAuth
+    description: |
+      ランチャーの認証関連のAPIです。
   - name: seat
+    description: |
+      席管理関連のAPIです。
 
 paths:
   # oauth2

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -509,12 +509,12 @@ paths:
         - gameRole
       security:
         - GameOwnerAuth: []
-      operationId: postGameRole
+      operationId: patchGameRole
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GameRole'
+              $ref: '#/components/schemas/GameRoleRequest'
       responses:
         "200":
           content:
@@ -552,8 +552,60 @@ paths:
           $ref: '#/components/responses/InternalServerError'
       summary: ゲームの管理権限の変更
       description: |
-        指定したゲームIDのゲームの管理権限を変更します。
-        ownerは1人以上はいる必要があります。
+        指定したゲームIDのゲームの管理者を追加します。
+        既に指定のユーザーが権限(ownerまたはmaintainer)として登録されている場合は、
+        指定された権限で権限を上書きします。
+    delete:
+      tags:
+        - gameRole
+      security:
+        - GameOwnerAuth: []
+      operationId: deleteGameRole
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GameRoleRequest'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Game'
+          description: |
+            ゲームの管理権限の変更に成功した際に返されます。
+            レスポンスで変更後のowner、maintainerを含むゲーム情報が返されます。
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            ゲームID、またはリクエストが不正である場合に返されます。
+            削除によりゲームにownerが存在しなくなる場合にも返されます。
+        "401":
+          $ref: '#/components/responses/TraPUnauthorized'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            このゲームのownerでない場合に返されます。
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            指定したIDのゲームが存在しない、または削除されている場合に返されます。
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: ゲームの管理権限の削除
+      description: |
+        指定したゲームIDのゲームの管理権限を削除します。
+        ownerは1人以上はいる必要があるため、
+        削除によりownerがいなくなる場合はエラーとなります。
 
   # gameVersion
   /games/{gameID}/versions:
@@ -1967,6 +2019,17 @@ components:
       description: |
         ゲームの一覧を取得します。
         ページングのために、limit、offsetを適用する前のゲームの数をnumで返しています。
+    GameRoleRequest:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UserID'
+        type:
+          $ref: '#/components/schemas/GameRoleType'
+      required:
+        - id
+      description: |
+        ゲームのロールを指定するリクエストです。
     GetGameVersionsResponse:
       type: object
       properties:
@@ -2469,6 +2532,17 @@ components:
       format: date-time
       description: |
         ゲームがtraP Collectionに追加された時刻です。
+
+    # ゲームの管理権限
+    GameRoleType:
+      type: string
+      enum:
+        - owner
+        - maintainer
+      description: |
+        ゲームの管理権限の種類です。
+        ownerはゲームの所有者で、ゲーム情報の変更や管理者の変更ができます。
+        maintainerはゲームのメンテナーで、ゲーム情報の変更のみできます。
 
     # ゲームバージョン
     GameVersionID:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -311,11 +311,13 @@ paths:
               $ref: '#/components/schemas/PatchGame'
       responses:
         "200":
-          description: 成功
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Game'
+          description: |
+            ゲームの情報の修正に成功した際に返されます。
+            レスポンスで修正後のゲームの情報が返されます。
         "400":
           description: |
             ゲームID、またはリクエストが不正である場合に返されます。

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -553,17 +553,16 @@ paths:
         指定したゲームIDのゲームの管理者を追加します。
         既に指定のユーザーが権限(ownerまたはmaintainer)として登録されている場合は、
         指定された権限で権限を上書きします。
+  /games/{gameID}/roles/{userID}:
+    parameters:
+      - $ref: '#/components/parameters/gameIDInPath'
+      - $ref: '#/components/parameters/userIDInPath'
     delete:
       tags:
         - gameRole
       security:
         - GameOwnerAuth: []
       operationId: deleteGameRole
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GameRoleRequest'
       responses:
         "200":
           content:

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -312,7 +312,8 @@ paths:
       operationId: deleteGames
       responses:
         "200":
-          description: 成功
+          description: |
+            ゲームの削除に成功した際に返されます。
         "400":
           description: |
             ゲームIDが不正な値である場合に返されます。

--- a/docs/v2-openapi.yaml
+++ b/docs/v2-openapi.yaml
@@ -563,6 +563,8 @@ components:
         message:
           type: string
           example: Internal Server Error
+      required:
+        - message
     OperatingSystem:
       type: string
       enum:
@@ -574,13 +576,19 @@ components:
         num:
           type: integer
           description: |
-            取得したゲームの数です。
+            limit、offsetが適用される前のゲームの数です。
         games:
           type: array
           items:
             $ref: '#/components/schemas/Game'
           description: |
-            ゲームの一覧です。
+            limit、offsetが適用された後のゲームの一覧です。
+      required:
+        - num
+        - games
+      description: |
+        ゲームの一覧を取得します。
+        ページングのために、limit、offsetを適用する前のゲームの数をnumで返しています。
     GameRoleResponse:
       type: object
       properties:
@@ -596,6 +604,11 @@ components:
             $ref: '#/components/schemas/UserName'
           description: |
             ゲームのmaintainerの一覧です。
+            maintainerがいない場合、このフィールドは存在しません。
+      required:
+        - owners
+      description: |
+        ゲームのownerとmaintainerの一覧です。
 
     # エンティティ
     # ユーザー
@@ -653,6 +666,9 @@ components:
           $ref: '#/components/schemas/GameName'
         description:
           $ref: '#/components/schemas/GameDescription'
+      required:
+        - name
+        - description
       description: |
         ゲームの情報を修正する際に必要な情報です。
     Game:
@@ -727,16 +743,28 @@ components:
 
     # ゲームバージョン
     NewGameVersion:
-      description: 新しいゲームのバージョン
       type: object
       properties:
         name:
           $ref: '#/components/schemas/GameVersionName'
         description:
           $ref: '#/components/schemas/GameVersionDescription'
+        url:
+          $ref: '#/components/schemas/GameURL'
+        file:
+          $ref: '#/components/schemas/GameFileGroup'
+        imageID:
+          $ref: '#/components/schemas/GameImageID'
+        videoID:
+          $ref: '#/components/schemas/GameVideoID'
       required:
         - name
         - description
+        - imageID
+        - videoID
+      description: |
+        新しいゲームのバージョンです。
+        url、fileはゲームの種類に応じていずれかが存在します。
     GameVersion:
       type: object
       properties:
@@ -746,6 +774,18 @@ components:
           $ref: '#/components/schemas/GameVersionName'
         description:
           $ref: '#/components/schemas/GameVersionDescription'
+        url:
+          $ref: '#/components/schemas/GameURL'
+        files:
+          type: array
+          minLength: 1
+          maxLength: 3
+          items:
+            $ref: '#/components/schemas/GameFileID'
+        imageID:
+          $ref: '#/components/schemas/GameImageID'
+        videoID:
+          $ref: '#/components/schemas/GameVideoID'
         createdAt:
           $ref: '#/components/schemas/GameVersionCreatedAt'
       required:
@@ -753,6 +793,8 @@ components:
         - name
         - description
         - createdAt
+      description: |
+        ゲームのファイルです。
 
     # 値オブジェクト
     # ユーザー
@@ -827,3 +869,89 @@ components:
       format: date-time
       description: |
         ゲームのバージョンが作成された時刻です。
+
+    # ゲームファイル
+    GameFileID:
+      type: string
+      format: uuid
+      description: |
+        ゲームファイルのIDです。
+    GameFileMd5:
+      type: string
+      pattern: ^[0-9a-f]{32}$
+      example: 3bccfb0579ab5d81289c459aa8c9a1b0
+      description: |
+        ゲームファイルのmd5ハッシュ値です。
+    GameFileEntryPoint:
+      type: string
+      example: PPP.exe
+      description: |
+        ゲームファイルの解凍後の実行ファイルのパスです。
+    GameFileContent:
+      type: string
+      format: binary
+      description: |
+        ゲームの実行ファイルやデータをzipしたバイナリです。
+    GameFileCreatedAt:
+      type: string
+      format: date-time
+      description: |
+        ゲームファイルが作成された時刻です。
+        サーバーでの未使用ゲームファイルの削除にのみ使用されます。
+
+    # ゲームURL
+    GameURL:
+      type: string
+      format: uri
+      description: |
+        ゲームのURLの値です。
+
+    # ゲーム画像
+    GameImageID:
+      type: string
+      format: uuid
+      description: |
+        ゲーム画像のIDです。
+    GameImageType:
+      type: string
+      enum:
+        - jpeg
+        - png
+        - gif
+      description: |
+        ゲーム画像の種類です。
+    GameImageContent:
+      type: string
+      format: binary
+      description: |
+        ゲーム画像のバイナリです。
+    GameImageCreatedAt:
+      type: string
+      format: date-time
+      description: |
+        ゲーム画像の作成時刻です。
+        サーバーでの未使用画像の削除にのみ使用されます。
+
+    # ゲーム紹介動画
+    GameVideoID:
+      type: string
+      format: uuid
+      description: |
+        ゲーム紹介動画のIDです。
+    GameVideoType:
+      type: string
+      enum:
+        - mp4
+      description: |
+        ゲーム紹介動画の種類です。
+    GameVideoContent:
+      type: string
+      format: binary
+      description: |
+        ゲーム紹介動画のバイナリです。
+    GameVideoCreatedAt:
+      type: string
+      format: date-time
+      description: |
+        ゲーム紹介動画の作成時刻です。
+        サーバーでの未使用動画の削除にのみ使用されます。


### PR DESCRIPTION
v2のAPI設計。

# 主要な変更点
## ランチャーバージョンにゲームバージョンを対応させる
これまで、ランチャーバージョンにゲームを紐付け、ランチャーに入っているゲームを設定していた。
しかし、これでは工大祭とコミケで異なるゲームバージョンを配信したい場合や、
過去のコミケで配信したものに機能追加したゲームバージョンを次のコミケでは販売したい場合などに対応できなかった。
これをに対応するために、ランチャーバージョンにゲームではなくゲームバージョンを紐付けるように変更した。

### v1との互換性維持方法
v1のAPIでランチャーバージョンにゲームを紐付けられているゲームについては、
現在常に最新のゲームバージョンが配信されるようになっている。
このため、同様の挙動となるよう、各ゲームの最新バージョンをランチャーに紐付けることで対応する。

## ゲーム画像と動画をゲームバージョンに紐づけ
これまではゲーム自体に紐づいていたゲーム画像と動画は紐づいていた。
しかし、ゲーム画像と動画はゲームの機能追加などのアップデートにより変わる。
このため、ゲーム画像と動画をゲームバージョンに紐づくように変更した。

### 画像・動画ファイルの増加への対策
画像・動画ファイルを再利用可能なようにapiを設計している。
このため、Web UIを過去と同じ画像や動画をバージョン追加時に利用できるように作ることで、
無駄な画像・動画ファイルの増加を抑えることができる。

### v1との互換性維持方法
現在ゲームに紐づいている画像・動画を過去も含めて全てのゲームバージョンに紐づけることで対応する。
現在、最新のゲームバージョンしか利用されない状態となっているため、これによる挙動の変化はない。
懸念点として、過去のゲームバージョンで画像・動画とゲーム内容が一致しない可能性があり、
このようなゲームバージョンをランチャーと紐付けないように運用で対処する必要がある点がある。
ただ、対応する画像・動画が存在しない特殊なゲームバージョンが生まれると、
今後の開発で扱いが面倒になるので、ここでこのような対処をしてしまった方が良いと思っている。

## `/versions/check`の廃止
サーバーサイドの無駄な実装コストの削減のために、他で代用可能な機能しかもなたない`/versions/check`を廃止する。
ランチャー側でAPIを叩く実装コストが増える点については確認済み。
リクエスト数の増加については、
UXの観点はその後行われるファイルのダウンロードを比べたら誤差程度の速度低下しか怒らないと思われるため問題なし、
サーバーの負荷の観点は現状の負荷では特に問題ない。
100以上のゲームの入ったランチャーが大量に同時に起動された場合にサーバーの負荷面で問題が発生する可能性があるが、
オンメモリキャッシュにより対処が可能であり、こちらの方が`/versions/check`の実装コストより低いと思われるため、
そのような事例が発生しそうな場合にオンメモリキャッシュを実装する方針にする。

## traP Collection全体の管理者変更をAPIからできるように
これまで環境変数で指定していたtraP Collection全体の管理者を、
APIから変更できるようにしている。
環境変数で指定されていると、管理者変更のたびにtokyotech.orgのansibleをいじる必要がありかなり面倒だった。
これを、APIから変更できるようにした。

### 初期の管理者
APIで管理者を変更する権限は管理者のみにある。
このため、初期の管理者が必要になる。
この初期の管理者はこれまでと同様に環境変数で設定するつもりでいる。
挙動としては、「起動時に管理者が誰もいない場合のみ初期管理者を管理者に追加する」が
基本的にAPIで管理者を変更することを強制でき良い気がしているが、議論の余地あり。

## プロダクトキーの再activate
これまで、誤ってプロダクトキーをrevokeしてしまった場合、何らかの手段でプロダクトキー購入者と連絡をとって新しいプロダクトキーを渡す必要があり、リスクが大きいため実質的にrevokeすることができなかった。
このため、管理者向けに誤ってrevokeしてしまったプロダクトキーを再activateできるエンドポイントを追加した。

# 注意点
上記の変更により発生する確認してほしい点。
## ゲーム追加時のフロー変更
v1では以下のような手順だった。
1. ゲーム追加: `POST /games`
2. 画像、動画追加: `POST /games/{gameID}/image`,`POST /games/{gameID}/video`
2. ゲームバージョン追加: `POST /games/{gameID}/version`
2. ファイル、url追加: `POST /games/asset/{gameID}/file`,`POST /games/asset/{gameID}/url`

v2では以下のようになる。
1. 画像、動画、ファイル追加: `POST /games}/images`,`POST /games/videos`,`POST /games/files`
1. ゲーム追加: `POST /games`
    - 同時にゲームバージョンも追加する

端的にいうと、
- 画像、動画、ファイルをゲーム追加前にアップロードする
- 初期のゲームバージョンをゲーム追加と同時に設定する

の2点が違う。
これにより、v1ではゲームバージョンが追加された直後にランチャーが起動されるとファイルが紐づいていない場合があった問題が解消される。
