### PR TITLE
認証サービス実装

### DIFF
--- a/src/auth/user.go
+++ b/src/auth/user.go
@@ -11,5 +11,11 @@ import (
 
 type User interface {
 	GetMe(ctx context.Context, session *domain.OIDCSession) (*service.UserInfo, error)
+	// GetAllActiveUsers
+	// deplicated
+	// メソッド名にAllをつけない方が統一感があって良いので、GetActiveUsersに変更する
 	GetAllActiveUsers(ctx context.Context, session *domain.OIDCSession) ([]*service.UserInfo, error)
+	// GetActiveUsers
+	// traQの全アクティブユーザー(凍結されていないユーザー)の取得。
+	GetActiveUsers(ctx context.Context, session *domain.OIDCSession) ([]*service.UserInfo, error)
 }

--- a/src/cache/user.go
+++ b/src/cache/user.go
@@ -13,6 +13,22 @@ import (
 type User interface {
 	GetMe(ctx context.Context, accessToken values.OIDCAccessToken) (*service.UserInfo, error)
 	SetMe(ctx context.Context, session *domain.OIDCSession, user *service.UserInfo) error
+	// GetAllActiveUsers
+	// deplicated
+	// メソッド名にAllをつけない方が統一感があって良いので、GetActiveUsersに変更する
+	// v1 API削除時に廃止する
 	GetAllActiveUsers(ctx context.Context) ([]*service.UserInfo, error)
+	// SetAllActiveUsers
+	// deplicated
+	// メソッド名にAllをつけない方が統一感があって良いので、SetActiveUsersに変更する
+	// v1 API削除時に廃止する
 	SetAllActiveUsers(ctx context.Context, users []*service.UserInfo) error
+	// GetActiveUsers
+	// traQの全アクティブユーザー(凍結されていないユーザー)のキャッシュ取得。
+	// キャッシュ設定から1時間の間有効。
+	// このため、traQでの凍結・凍結解除の反映までに最大1時間の遅延が発生する点に注意。
+	GetActiveUsers(ctx context.Context) ([]*service.UserInfo, error)
+	// SetActiveUsers
+	// traQの全アクティブユーザー(凍結されていないユーザー)のキャッシュ設定。
+	SetActiveUsers(ctx context.Context, users []*service.UserInfo) error
 }

--- a/src/config/service.go
+++ b/src/config/service.go
@@ -7,3 +7,13 @@ type ServiceV1 interface {
 	ClientID() (string, error)
 	ClientSecret() (string, error)
 }
+
+type ServiceV2 interface {
+	// ClientID
+	// OIDC・OAuth2.0(Authorization Code Flow)のClientIDを取得する
+	ClientID() (string, error)
+	// ClientSecret
+	// OIDC・OAuth2.0(Authorization Code Flow)のClientSecretを取得する
+	// traQではSecret関連の機能は未実装なため、基本的に使うことはない
+	ClientSecret() (string, error)
+}

--- a/src/config/v1/service.go
+++ b/src/config/v1/service.go
@@ -40,3 +40,27 @@ func (*ServiceV1) ClientSecret() (string, error) {
 
 	return clientSecret, nil
 }
+
+type ServiceV2 struct{}
+
+func NewServiceV2() *ServiceV2 {
+	return &ServiceV2{}
+}
+
+func (*ServiceV2) ClientID() (string, error) {
+	clientID, ok := os.LookupEnv(envKeyClientID)
+	if !ok {
+		return "", errors.New("ENV CLIENT_ID IS NULL")
+	}
+
+	return clientID, nil
+}
+
+func (*ServiceV2) ClientSecret() (string, error) {
+	clientSecret, ok := os.LookupEnv(envKeyClientSecret)
+	if !ok {
+		return "", errors.New("ENV CLIENT_SECRET IS NULL")
+	}
+
+	return clientSecret, nil
+}

--- a/src/service/v2/oidc.go
+++ b/src/service/v2/oidc.go
@@ -1,0 +1,160 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/traPtitech/trap-collection-server/src/auth"
+	"github.com/traPtitech/trap-collection-server/src/cache"
+	"github.com/traPtitech/trap-collection-server/src/config"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/service"
+)
+
+// OIDC構造体がservice.OIDCV2インターフェイスを満たすことを示すおまじない
+var _ service.OIDCV2 = &OIDC{}
+
+type OIDC struct {
+	client   *domain.OIDCClient
+	user     *User
+	oidcAuth auth.OIDC
+}
+
+func NewOIDC(conf config.ServiceV2, user *User, oidc auth.OIDC) (*OIDC, error) {
+	strClientID, err := conf.ClientID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client ID: %w", err)
+	}
+
+	clientID := values.NewOIDCClientID(string(strClientID))
+
+	client := domain.NewOIDCClient(clientID)
+
+	return &OIDC{
+		client:   client,
+		user:     user,
+		oidcAuth: oidc,
+	}, nil
+}
+
+func (o *OIDC) GenerateAuthState(ctx context.Context) (*domain.OIDCClient, *domain.OIDCAuthState, error) {
+	codeChallengeMethod := values.OIDCCodeChallengeMethodSha256
+	codeChallenge, err := values.NewOIDCCodeVerifier()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate code verifier: %w", err)
+	}
+
+	state := domain.NewOIDCAuthState(codeChallengeMethod, codeChallenge)
+
+	return o.client, state, nil
+}
+
+func (o *OIDC) Callback(ctx context.Context, authState *domain.OIDCAuthState, code values.OIDCAuthorizationCode) (*domain.OIDCSession, error) {
+	session, err := o.oidcAuth.GetOIDCSession(ctx, o.client, code, authState)
+	if errors.Is(err, auth.ErrInvalidCredentials) {
+		return nil, service.ErrInvalidAuthStateOrCode
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OIDC session: %w", err)
+	}
+
+	return session, nil
+}
+
+func (o *OIDC) Logout(ctx context.Context, session *domain.OIDCSession) error {
+	err := o.oidcAuth.RevokeOIDCSession(ctx, session)
+	if err != nil {
+		return fmt.Errorf("failed to revoke OIDC session: %w", err)
+	}
+
+	return nil
+}
+
+func (o *OIDC) Authenticate(ctx context.Context, session *domain.OIDCSession) error {
+	// traQで凍結された場合の反映が遅れるのは許容しているので、sessionの有効期限確認のみ
+	if session.IsExpired() {
+		return service.ErrOIDCSessionExpired
+	}
+
+	return nil
+}
+
+func (o *OIDC) GetMe(ctx context.Context, session *domain.OIDCSession) (*service.UserInfo, error) {
+	return o.user.getMe(ctx, session)
+}
+
+func (o *OIDC) GetActiveUsers(ctx context.Context, session *domain.OIDCSession) ([]*service.UserInfo, error) {
+	return o.user.getActiveUsers(ctx, session)
+}
+
+// User
+// traPメンバーの情報取得周りをキャッシュの使用も含めて行う。
+type User struct {
+	userAuth  auth.User
+	userCache cache.User
+}
+
+func NewUser(userAuth auth.User, userCache cache.User) *User {
+	return &User{
+		userAuth:  userAuth,
+		userCache: userCache,
+	}
+}
+
+// getMe
+// セッションから対応するtraQのユーザー情報を取得する。
+// traQでの凍結・凍結解除の反映までに最大1時間の遅延が発生する点に注意。
+func (uu *User) getMe(ctx context.Context, session *domain.OIDCSession) (*service.UserInfo, error) {
+	user, err := uu.userCache.GetMe(ctx, session.GetAccessToken())
+	if err != nil && !errors.Is(err, cache.ErrCacheMiss) {
+		// cacheからの取り出しに失敗してもauthからとって来れれば良いので、returnはしない
+		log.Printf("error: failed to get user info: %v\n", err)
+	}
+	// cacheから取り出した場合はそれを返す
+	if err == nil {
+		return user, nil
+	}
+
+	user, err = uu.userAuth.GetMe(ctx, session)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user info: %w", err)
+	}
+
+	err = uu.userCache.SetMe(ctx, session, user)
+	if err != nil {
+		// cacheの設定に失敗してもreturnはしない
+		log.Printf("error: failed to set user info: %v\n", err)
+	}
+
+	return user, nil
+}
+
+// getActiveUsers
+// traQのアクティブユーザー(凍結されていないユーザー)一覧を取得する。
+func (uu *User) getActiveUsers(ctx context.Context, session *domain.OIDCSession) ([]*service.UserInfo, error) {
+	users, err := uu.userCache.GetActiveUsers(ctx)
+	if err != nil && !errors.Is(err, cache.ErrCacheMiss) {
+		// cacheからの取り出しに失敗してもauthからとって来れれば良いので、returnはしない
+		log.Printf("error: failed to get user info: %v\n", err)
+	}
+	// cacheから取り出した場合はそれを返す
+	if err == nil {
+		return users, nil
+	}
+
+	users, err = uu.userAuth.GetActiveUsers(ctx, session)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user info: %w", err)
+	}
+
+	err = uu.userCache.SetActiveUsers(ctx, users)
+	if err != nil {
+		// cacheの設定に失敗してもreturnはしない
+		log.Printf("error: failed to set user info: %v\n", err)
+	}
+
+	return users, nil
+}

--- a/src/service/v2/oidc_test.go
+++ b/src/service/v2/oidc_test.go
@@ -1,0 +1,532 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/trap-collection-server/src/auth"
+	"github.com/traPtitech/trap-collection-server/src/auth/mock"
+	mockAuth "github.com/traPtitech/trap-collection-server/src/auth/mock"
+	"github.com/traPtitech/trap-collection-server/src/cache"
+	mockCache "github.com/traPtitech/trap-collection-server/src/cache/mock"
+	mockConfig "github.com/traPtitech/trap-collection-server/src/config/mock"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/service"
+)
+
+func TestGenerateAuthState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOIDCAuth := mock.NewMockOIDC(ctrl)
+
+	mockConf := mockConfig.NewMockServiceV1(ctrl)
+	mockConf.
+		EXPECT().
+		ClientID().
+		Return("clientID", nil)
+	mockUserCache := mockCache.NewMockUser(ctrl)
+	mockUserAuth := mockAuth.NewMockUser(ctrl)
+	user := NewUser(mockUserAuth, mockUserCache)
+	oidcService, err := NewOIDC(mockConf, user, mockOIDCAuth)
+	if err != nil {
+		t.Fatalf("failed to create oidc service: %v", err)
+		return
+	}
+
+	client, session, err := oidcService.GenerateAuthState(ctx)
+	assert.NoError(t, err)
+
+	assert.Equal(t, oidcService.client, client)
+	assert.Equal(t, values.OIDCCodeChallengeMethodSha256, session.GetCodeChallengeMethod())
+}
+
+func TestCallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOIDCAuth := mock.NewMockOIDC(ctrl)
+
+	mockConf := mockConfig.NewMockServiceV1(ctrl)
+	mockConf.
+		EXPECT().
+		ClientID().
+		Return("clientID", nil)
+	mockUserCache := mockCache.NewMockUser(ctrl)
+	mockUserAuth := mockAuth.NewMockUser(ctrl)
+	user := NewUser(mockUserAuth, mockUserCache)
+	oidcService, err := NewOIDC(mockConf, user, mockOIDCAuth)
+	if err != nil {
+		t.Fatalf("failed to create oidc service: %v", err)
+		return
+	}
+
+	type test struct {
+		description       string
+		GetOIDCSessionErr error
+		isErr             bool
+		err               error
+	}
+
+	testCases := []test{
+		{
+			description: "エラーなしなので問題なし",
+		},
+		{
+			description:       "GetOIDCSessionでErrInvalidCredentials",
+			GetOIDCSessionErr: auth.ErrInvalidCredentials,
+			isErr:             true,
+			err:               service.ErrInvalidAuthStateOrCode,
+		},
+		{
+			description:       "GetOIDCSessionでエラー",
+			GetOIDCSessionErr: errors.New("error"),
+			isErr:             true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			codeVerifier, err := values.NewOIDCCodeVerifier()
+			assert.NoError(t, err)
+
+			code := values.NewOIDCAuthorizationCode("")
+			authState := domain.NewOIDCAuthState(
+				values.OIDCCodeChallengeMethodSha256,
+				codeVerifier,
+			)
+			var session *domain.OIDCSession
+			if testCase.GetOIDCSessionErr == nil {
+				session = domain.NewOIDCSession(
+					values.NewOIDCAccessToken("access token"),
+					time.Now(),
+				)
+			}
+			mockOIDCAuth.
+				EXPECT().
+				GetOIDCSession(ctx, oidcService.client, code, authState).
+				Return(session, testCase.GetOIDCSessionErr)
+
+			actualSession, err := oidcService.Callback(ctx, authState, code)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, session, actualSession)
+		})
+	}
+}
+
+func TestLogout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOIDCAuth := mock.NewMockOIDC(ctrl)
+
+	mockConf := mockConfig.NewMockServiceV1(ctrl)
+	mockConf.
+		EXPECT().
+		ClientID().
+		Return("clientID", nil)
+	mockUserCache := mockCache.NewMockUser(ctrl)
+	mockUserAuth := mockAuth.NewMockUser(ctrl)
+	user := NewUser(mockUserAuth, mockUserCache)
+	oidcService, err := NewOIDC(mockConf, user, mockOIDCAuth)
+	if err != nil {
+		t.Fatalf("failed to create oidc service: %v", err)
+		return
+	}
+
+	type test struct {
+		description          string
+		RevokeOIDCSessionErr error
+		isErr                bool
+		err                  error
+	}
+
+	testCases := []test{
+		{
+			description: "エラーなしなので問題なし",
+		},
+		{
+			description:          "GetOIDCSessionでエラー",
+			RevokeOIDCSessionErr: errors.New("error"),
+			isErr:                true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			session := domain.NewOIDCSession(
+				values.NewOIDCAccessToken("access token"),
+				time.Now(),
+			)
+			mockOIDCAuth.
+				EXPECT().
+				RevokeOIDCSession(ctx, session).
+				Return(testCase.RevokeOIDCSessionErr)
+
+			err := oidcService.Logout(ctx, session)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAuthenticate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOIDCAuth := mock.NewMockOIDC(ctrl)
+
+	mockConf := mockConfig.NewMockServiceV1(ctrl)
+	mockConf.
+		EXPECT().
+		ClientID().
+		Return("clientID", nil)
+	mockUserCache := mockCache.NewMockUser(ctrl)
+	mockUserAuth := mockAuth.NewMockUser(ctrl)
+	user := NewUser(mockUserAuth, mockUserCache)
+	oidcService, err := NewOIDC(mockConf, user, mockOIDCAuth)
+	if err != nil {
+		t.Fatalf("failed to create oidc service: %v", err)
+		return
+	}
+
+	type test struct {
+		description string
+		isExpired   bool
+		isErr       bool
+		err         error
+	}
+
+	testCases := []test{
+		{
+			description: "期限前なので問題なし",
+		},
+		{
+			description: "期限切れなのでエラー",
+			isExpired:   true,
+			isErr:       true,
+			err:         service.ErrOIDCSessionExpired,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			var expiresAt time.Time
+			if testCase.isExpired {
+				expiresAt = time.Now().Add(-1 * time.Hour)
+			} else {
+				expiresAt = time.Now().Add(1 * time.Hour)
+			}
+
+			session := domain.NewOIDCSession(
+				values.NewOIDCAccessToken("access token"),
+				expiresAt,
+			)
+
+			err := oidcService.Authenticate(ctx, session)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetMe(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOIDCAuth := mock.NewMockOIDC(ctrl)
+
+	mockConf := mockConfig.NewMockServiceV1(ctrl)
+	mockConf.
+		EXPECT().
+		ClientID().
+		Return("clientID", nil)
+	mockUserCache := mockCache.NewMockUser(ctrl)
+	mockUserAuth := mockAuth.NewMockUser(ctrl)
+	user := NewUser(mockUserAuth, mockUserCache)
+	oidcService, err := NewOIDC(mockConf, user, mockOIDCAuth)
+	if err != nil {
+		t.Fatalf("failed to create oidc service: %v", err)
+		return
+	}
+
+	type test struct {
+		description      string
+		cacheUser        *service.UserInfo
+		cacheGetMeErr    error
+		executeAuthGetMe bool
+		authUser         *service.UserInfo
+		authGetMeErr     error
+		cacheSetMeErr    error
+		user             *service.UserInfo
+		isErr            bool
+		err              error
+	}
+
+	userInfo := service.NewUserInfo(
+		values.NewTrapMemberID(uuid.New()),
+		values.NewTrapMemberName("mazrean"),
+		values.TrapMemberStatusActive,
+	)
+
+	testCases := []test{
+		{
+			description: "cacheがhitするのでエラーなし",
+			cacheUser:   userInfo,
+			user:        userInfo,
+		},
+		{
+			description:      "cacheがhitしないがauthからの取り出しに成功するのでエラーなし",
+			cacheGetMeErr:    cache.ErrCacheMiss,
+			executeAuthGetMe: true,
+			authUser:         userInfo,
+			user:             userInfo,
+		},
+		{
+			description:      "cacheがエラー(ErrCacheMiss以外)でもauthからの取り出しに成功するのでエラーなし",
+			cacheGetMeErr:    errors.New("cache error"),
+			executeAuthGetMe: true,
+			authUser:         userInfo,
+			user:             userInfo,
+		},
+		{
+			description:      "cacheがhitせずauthからの取り出しがエラーなのでエラー",
+			cacheGetMeErr:    cache.ErrCacheMiss,
+			executeAuthGetMe: true,
+			authGetMeErr:     errors.New("auth error"),
+			isErr:            true,
+		},
+		{
+			description:      "cacheがhitしないがauthからの取り出しに成功するのでcache設定に失敗してもエラーなし",
+			cacheGetMeErr:    cache.ErrCacheMiss,
+			executeAuthGetMe: true,
+			authUser:         userInfo,
+			cacheSetMeErr:    errors.New("cache error"),
+			user:             userInfo,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			session := domain.NewOIDCSession(
+				values.NewOIDCAccessToken("access token"),
+				time.Now(),
+			)
+
+			mockUserCache.
+				EXPECT().
+				GetMe(ctx, session.GetAccessToken()).
+				Return(testCase.cacheUser, testCase.cacheGetMeErr)
+			if testCase.executeAuthGetMe {
+				mockUserAuth.
+					EXPECT().
+					GetMe(ctx, session).
+					Return(testCase.authUser, testCase.authGetMeErr)
+				if testCase.authGetMeErr == nil {
+					mockUserCache.
+						EXPECT().
+						SetMe(ctx, session, testCase.authUser).
+						Return(testCase.cacheSetMeErr)
+				}
+			}
+
+			user, err := oidcService.GetMe(ctx, session)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, testCase.user, user)
+		})
+	}
+}
+
+func TestGetActiveUsers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOIDCAuth := mock.NewMockOIDC(ctrl)
+
+	mockConf := mockConfig.NewMockServiceV1(ctrl)
+	mockConf.
+		EXPECT().
+		ClientID().
+		Return("clientID", nil)
+	mockUserCache := mockCache.NewMockUser(ctrl)
+	mockUserAuth := mockAuth.NewMockUser(ctrl)
+	user := NewUser(mockUserAuth, mockUserCache)
+	oidcService, err := NewOIDC(mockConf, user, mockOIDCAuth)
+	if err != nil {
+		t.Fatalf("failed to create oidc service: %v", err)
+		return
+	}
+
+	type test struct {
+		description                  string
+		cacheUsers                   []*service.UserInfo
+		cacheGetAllActiveUsersErr    error
+		executeAuthGetAllActiveUsers bool
+		authUsers                    []*service.UserInfo
+		authGetAllActiveUsersErr     error
+		cacheSetAllActiveUsersErr    error
+		users                        []*service.UserInfo
+		isErr                        bool
+		err                          error
+	}
+
+	users := []*service.UserInfo{
+		service.NewUserInfo(
+			values.NewTrapMemberID(uuid.New()),
+			values.NewTrapMemberName("mazrean"),
+			values.TrapMemberStatusActive,
+		),
+	}
+
+	testCases := []test{
+		{
+			description: "cacheがhitするのでエラーなし",
+			cacheUsers:  users,
+			users:       users,
+		},
+		{
+			description:                  "cacheがhitしないがauthからの取り出しに成功するのでエラーなし",
+			cacheGetAllActiveUsersErr:    cache.ErrCacheMiss,
+			executeAuthGetAllActiveUsers: true,
+			authUsers:                    users,
+			users:                        users,
+		},
+		{
+			description:                  "cacheがエラー(ErrCacheMiss以外)でもauthからの取り出しに成功するのでエラーなし",
+			cacheGetAllActiveUsersErr:    errors.New("cache error"),
+			executeAuthGetAllActiveUsers: true,
+			authUsers:                    users,
+			users:                        users,
+		},
+		{
+			description:                  "cacheがhitせずauthからの取り出しがエラーなのでエラー",
+			cacheGetAllActiveUsersErr:    cache.ErrCacheMiss,
+			executeAuthGetAllActiveUsers: true,
+			authGetAllActiveUsersErr:     errors.New("auth error"),
+			isErr:                        true,
+		},
+		{
+			description:                  "cacheがhitしないがauthからの取り出しに成功するのでcache設定に失敗してもエラーなし",
+			cacheGetAllActiveUsersErr:    cache.ErrCacheMiss,
+			executeAuthGetAllActiveUsers: true,
+			authUsers:                    users,
+			cacheSetAllActiveUsersErr:    errors.New("cache error"),
+			users:                        users,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			session := domain.NewOIDCSession(
+				values.NewOIDCAccessToken("access token"),
+				time.Now(),
+			)
+
+			mockUserCache.
+				EXPECT().
+				GetActiveUsers(ctx).
+				Return(testCase.cacheUsers, testCase.cacheGetAllActiveUsersErr)
+			if testCase.executeAuthGetAllActiveUsers {
+				mockUserAuth.
+					EXPECT().
+					GetActiveUsers(ctx, session).
+					Return(testCase.authUsers, testCase.authGetAllActiveUsersErr)
+				if testCase.authGetAllActiveUsersErr == nil {
+					mockUserCache.
+						EXPECT().
+						SetActiveUsers(ctx, testCase.authUsers).
+						Return(testCase.cacheSetAllActiveUsersErr)
+				}
+			}
+
+			users, err := oidcService.GetActiveUsers(ctx, session)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, testCase.users, users)
+		})
+	}
+}

--- a/src/service/v2_oidc.go
+++ b/src/service/v2_oidc.go
@@ -1,0 +1,42 @@
+package service
+
+//go:generate go run github.com/golang/mock/mockgen -source=$GOFILE -destination=mock/${GOFILE} -package=mock
+
+import (
+	"context"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
+
+// OIDCV2
+// v2用のOIDC・OAuth2.0(Authorization Code Flow)を使い認証を行うサービス
+// ref: https://trap.jp/post/1007/#:~:text=%E3%81%91%E3%81%BE%E3%81%9B%E3%82%93%E3%80%82-,Authorization%20Code%20Flow,-%E6%B5%81%E3%82%8C
+type OIDCV2 interface {
+	// GenerateAuthState
+	// AuthorizationCodeを認可サーバーにリクエストし、
+	// ブラウザに返すために必要なOIDCClientとOIDCAuthStateを返す
+	// refの「1. ブラウザで認証画面を開く」に相当
+	GenerateAuthState(ctx context.Context) (*domain.OIDCClient, *domain.OIDCAuthState, error)
+	// Callback
+	// ブラウザからAuthorization Codeなどを受け取り、
+	// traQからトークンを取得して、
+	// ログインセッションを発行する
+	// refの「6. Authorization Codeをアプリケーション（Back-End）へ渡す」から
+	// 「9. ログインセッションを発行する」に相当
+	Callback(ctx context.Context, authState *domain.OIDCAuthState, code values.OIDCAuthorizationCode) (*domain.OIDCSession, error)
+	// Logout
+	// traQにトークンは気のリクエストをした上で、
+	// ログインセッションを破棄する
+	Logout(ctx context.Context, session *domain.OIDCSession) error
+	// Authenticate
+	// ログインセッションを検証する
+	// セッションの有効期限が切れている場合、ErrOIDCSessionExpiredを返す
+	Authenticate(ctx context.Context, session *domain.OIDCSession) error
+	// GetMe
+	// sessionに対応するtraQのユーザー情報を取得する
+	GetMe(ctx context.Context, session *domain.OIDCSession) (*UserInfo, error)
+	// GetActiveUsers
+	// traQの全アクティブユーザー(凍結されていないユーザー)情報を取得する
+	GetActiveUsers(ctx context.Context, session *domain.OIDCSession) ([]*UserInfo, error)
+}


### PR DESCRIPTION
認証まわりのサービスを実装した。
認証に関しては中身はほぼ変わっていない。
まだcache、authに必要なメソッドの実装は追加していないため、buildには失敗する。
このため、一旦mainとは別にブランチを切って、そちらにPRを出している。