### PR TITLE
ゲーム画像関連のサービス実装

### DIFF
--- a/src/repository/v2_game_image.go
+++ b/src/repository/v2_game_image.go
@@ -1,0 +1,34 @@
+package repository
+
+//go:generate go run github.com/golang/mock/mockgen -source=$GOFILE -destination=mock/${GOFILE} -package=mock
+
+import (
+	"context"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
+
+// GameImageV2
+// ゲーム画像のメタデータの保存・取得。
+// ストレージに保存済みの画像のメタデータのみが見えるように使う。
+type GameImageV2 interface {
+	// SaveGameImage
+	// ゲーム画像のメタデータの保存。
+	// 他のスレッドからはストレージに保存済みの画像のみが見えるようにトランザクションをとるように注意する。
+	SaveGameImage(ctx context.Context, gameID values.GameID, image *domain.GameImage) error
+	// GetGameImage
+	// ゲーム画像のメタデータの取得。
+	// 既にストレージに保存済みの画像のみが取得できる。
+	GetGameImage(ctx context.Context, gameImageID values.GameImageID, lockType LockType) (*GameImageInfo, error)
+	// GetGameImages
+	// ゲームに対応するゲーム画像のメタデータ一覧の取得。
+	// 既にストレージに保存済みの画像のみが取得できる。
+	// 画像の並び順はCreateAtの降順。
+	GetGameImages(ctx context.Context, gameID values.GameID, lockType LockType) ([]*domain.GameImage, error)
+}
+
+type GameImageInfo struct {
+	*domain.GameImage
+	GameID values.GameID
+}

--- a/src/service/errors.go
+++ b/src/service/errors.go
@@ -14,6 +14,7 @@ var (
 	ErrNoGameManagementRoleUpdated       = errors.New("no game management role updated")
 	ErrInvalidRole                       = errors.New("invalid role")
 	ErrInvalidGameID                     = errors.New("invalid game id")
+	ErrInvalidGameImageID                = errors.New("invalid game image id")
 	ErrInvalidUserID                     = errors.New("invalid user id")
 	ErrForbidden                         = errors.New("forbidden")
 	ErrInvalidFormat                     = errors.New("invalid format")

--- a/src/service/v2/game_image.go
+++ b/src/service/v2/game_image.go
@@ -1,0 +1,30 @@
+package v2
+
+import (
+	"github.com/traPtitech/trap-collection-server/src/repository"
+	"github.com/traPtitech/trap-collection-server/src/service"
+	"github.com/traPtitech/trap-collection-server/src/storage"
+)
+
+var _ service.GameImageV2 = &GameImage{}
+
+type GameImage struct {
+	db                  repository.DB
+	gameRepository      repository.Game
+	gameImageRepository repository.GameImageV2
+	gameImageStorage    storage.GameImage
+}
+
+func NewGameImage(
+	db repository.DB,
+	gameRepository repository.Game,
+	gameImageRepository repository.GameImageV2,
+	gameImageStorage storage.GameImage,
+) *GameImage {
+	return &GameImage{
+		db:                  db,
+		gameRepository:      gameRepository,
+		gameImageRepository: gameImageRepository,
+		gameImageStorage:    gameImageStorage,
+	}
+}

--- a/src/service/v2/game_image.go
+++ b/src/service/v2/game_image.go
@@ -1,9 +1,20 @@
 package v2
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/h2non/filetype"
+	"github.com/h2non/filetype/matchers"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/repository"
 	"github.com/traPtitech/trap-collection-server/src/service"
 	"github.com/traPtitech/trap-collection-server/src/storage"
+	"golang.org/x/sync/errgroup"
 )
 
 var _ service.GameImageV2 = &GameImage{}
@@ -27,4 +38,98 @@ func NewGameImage(
 		gameImageRepository: gameImageRepository,
 		gameImageStorage:    gameImageStorage,
 	}
+}
+
+func (gameImage *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, gameID values.GameID) error {
+	err := gameImage.db.Transaction(ctx, nil, func(ctx context.Context) error {
+		// TODO: v2のgameRepositoryに変更
+		_, err := gameImage.gameRepository.GetGame(ctx, gameID, repository.LockTypeRecord)
+		if errors.Is(err, repository.ErrRecordNotFound) {
+			return service.ErrInvalidGameID
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get game: %w", err)
+		}
+
+		imageID := values.NewGameImageID()
+
+		eg, ctx := errgroup.WithContext(ctx)
+		fileTypePr, fileTypePw := io.Pipe()
+		filePr, filePw := io.Pipe()
+
+		eg.Go(func() error {
+			defer fileTypePr.Close()
+
+			fType, err := filetype.MatchReader(fileTypePr)
+			if err != nil {
+				return fmt.Errorf("failed to get file type: %w", err)
+			}
+
+			_, err = io.ReadAll(fileTypePr)
+			if err != nil {
+				return fmt.Errorf("failed to read file type: %w", err)
+			}
+
+			var imageType values.GameImageType
+			switch fType.Extension {
+			case matchers.TypeJpeg.Extension:
+				imageType = values.GameImageTypeJpeg
+			case matchers.TypePng.Extension:
+				imageType = values.GameImageTypePng
+			case matchers.TypeGif.Extension:
+				imageType = values.GameImageTypeGif
+			default:
+				return service.ErrInvalidFormat
+			}
+
+			image := domain.NewGameImage(
+				imageID,
+				imageType,
+				time.Now(),
+			)
+
+			err = gameImage.gameImageRepository.SaveGameImage(ctx, gameID, image)
+			if err != nil {
+				return fmt.Errorf("failed to save game image: %w", err)
+			}
+
+			return nil
+		})
+
+		eg.Go(func() error {
+			defer filePr.Close()
+
+			err = gameImage.gameImageStorage.SaveGameImage(ctx, filePr, imageID)
+			if err != nil {
+				return fmt.Errorf("failed to save game image file: %w", err)
+			}
+
+			return nil
+		})
+
+		eg.Go(func() error {
+			defer filePw.Close()
+			defer fileTypePw.Close()
+
+			mw := io.MultiWriter(fileTypePw, filePw)
+			_, err = io.Copy(mw, reader)
+			if err != nil {
+				return fmt.Errorf("failed to copy image: %w", err)
+			}
+
+			return nil
+		})
+
+		err = eg.Wait()
+		if err != nil {
+			return fmt.Errorf("failed to save game image: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed in transaction: %w", err)
+	}
+
+	return nil
 }

--- a/src/service/v2/game_image.go
+++ b/src/service/v2/game_image.go
@@ -133,3 +133,20 @@ func (gameImage *GameImage) SaveGameImage(ctx context.Context, reader io.Reader,
 
 	return nil
 }
+
+func (gameImage *GameImage) GetGameImages(ctx context.Context, gameID values.GameID) ([]*domain.GameImage, error) {
+	_, err := gameImage.gameRepository.GetGame(ctx, gameID, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, service.ErrInvalidGameID
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get game: %w", err)
+	}
+
+	images, err := gameImage.gameImageRepository.GetGameImages(ctx, gameID, repository.LockTypeNone)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get game images: %w", err)
+	}
+
+	return images, nil
+}

--- a/src/service/v2/game_image_test.go
+++ b/src/service/v2/game_image_test.go
@@ -1,0 +1,210 @@
+package v2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/repository"
+	mockRepository "github.com/traPtitech/trap-collection-server/src/repository/mock"
+	"github.com/traPtitech/trap-collection-server/src/service"
+	mockStorage "github.com/traPtitech/trap-collection-server/src/storage/mock"
+	"github.com/traPtitech/trap-collection-server/testdata"
+)
+
+func TestSaveGameImage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mockRepository.NewMockDB(ctrl)
+	mockGameRepository := mockRepository.NewMockGame(ctrl)
+	mockGameImageRepository := mockRepository.NewMockGameImageV2(ctrl)
+
+	type test struct {
+		description                    string
+		gameID                         values.GameID
+		isValidFile                    bool
+		imageType                      values.GameImageType
+		GetGameErr                     error
+		executeRepositorySaveGameImage bool
+		RepositorySaveGameImageErr     error
+		executeStorageSaveGameImage    bool
+		StorageSaveGameImageErr        error
+		isErr                          bool
+		err                            error
+	}
+
+	testCases := []test{
+		{
+			description:                    "特に問題ないのでエラーなし",
+			gameID:                         values.NewGameID(),
+			isValidFile:                    true,
+			imageType:                      values.GameImageTypeJpeg,
+			executeRepositorySaveGameImage: true,
+			executeStorageSaveGameImage:    true,
+		},
+		{
+			description: "GetGameがErrRecordNotFoundなのでErrInvalidGameID",
+			gameID:      values.NewGameID(),
+			isValidFile: true,
+			imageType:   values.GameImageTypeJpeg,
+			GetGameErr:  repository.ErrRecordNotFound,
+			isErr:       true,
+			err:         service.ErrInvalidGameID,
+		},
+		{
+			description: "GetGameがエラーなのでエラー",
+			gameID:      values.NewGameID(),
+			isValidFile: true,
+			imageType:   values.GameImageTypeJpeg,
+			GetGameErr:  errors.New("error"),
+			isErr:       true,
+		},
+		{
+			description:                    "画像がpngでもエラーなし",
+			gameID:                         values.NewGameID(),
+			isValidFile:                    true,
+			imageType:                      values.GameImageTypePng,
+			executeRepositorySaveGameImage: true,
+			executeStorageSaveGameImage:    true,
+		},
+		{
+			description:                    "画像がgifでもエラーなし",
+			gameID:                         values.NewGameID(),
+			isValidFile:                    true,
+			imageType:                      values.GameImageTypeGif,
+			executeRepositorySaveGameImage: true,
+			executeStorageSaveGameImage:    true,
+		},
+		{
+			description:                 "画像が不正なのでエラー",
+			gameID:                      values.NewGameID(),
+			executeStorageSaveGameImage: true,
+			isValidFile:                 false,
+			isErr:                       true,
+			err:                         service.ErrInvalidFormat,
+		},
+		{
+			description:                    "repository.SaveGameImageがエラーなのでエラー",
+			gameID:                         values.NewGameID(),
+			isValidFile:                    true,
+			imageType:                      values.GameImageTypeJpeg,
+			executeRepositorySaveGameImage: true,
+			executeStorageSaveGameImage:    true,
+			RepositorySaveGameImageErr:     errors.New("error"),
+			isErr:                          true,
+		},
+		{
+			description:                    "storage.SaveGameImageがエラーなのでエラー",
+			gameID:                         values.NewGameID(),
+			isValidFile:                    true,
+			imageType:                      values.GameImageTypeJpeg,
+			executeRepositorySaveGameImage: true,
+			executeStorageSaveGameImage:    true,
+			StorageSaveGameImageErr:        errors.New("error"),
+			isErr:                          true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+
+			mockGameImageStorage := mockStorage.NewGameImage(ctrl, buf)
+
+			gameImageService := NewGameImage(
+				mockDB,
+				mockGameRepository,
+				mockGameImageRepository,
+				mockGameImageStorage,
+			)
+
+			var file io.Reader
+			var expectBytes []byte
+			if testCase.isValidFile {
+				imgBuf := bytes.NewBuffer(nil)
+
+				err := func() error {
+					var path string
+					switch testCase.imageType {
+					case values.GameImageTypeJpeg:
+						path = "1.jpg"
+					case values.GameImageTypePng:
+						path = "1.png"
+					case values.GameImageTypeGif:
+						path = "1.gif"
+					default:
+						t.Fatalf("invalid image type: %v\n", testCase.imageType)
+					}
+					f, err := testdata.FS.Open(path)
+					if err != nil {
+						return fmt.Errorf("failed to open file: %w", err)
+					}
+					defer f.Close()
+
+					_, err = io.Copy(imgBuf, f)
+					if err != nil {
+						return fmt.Errorf("failed to copy file: %w", err)
+					}
+
+					return nil
+				}()
+				if err != nil {
+					t.Fatalf("failed to encode image: %s", err)
+				}
+
+				file = imgBuf
+				expectBytes = imgBuf.Bytes()
+			} else {
+				file = strings.NewReader("invalid file")
+			}
+
+			mockGameRepository.
+				EXPECT().
+				GetGame(gomock.Any(), testCase.gameID, repository.LockTypeRecord).
+				Return(nil, testCase.GetGameErr)
+
+			if testCase.executeRepositorySaveGameImage {
+				mockGameImageRepository.
+					EXPECT().
+					SaveGameImage(gomock.Any(), testCase.gameID, gomock.Any()).
+					Return(testCase.RepositorySaveGameImageErr)
+			}
+
+			if testCase.executeStorageSaveGameImage {
+				mockGameImageStorage.
+					EXPECT().
+					SaveGameImage(gomock.Any(), gomock.Any()).
+					Return(testCase.StorageSaveGameImageErr)
+			}
+
+			err := gameImageService.SaveGameImage(ctx, file, testCase.gameID)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil || testCase.isErr {
+				return
+			}
+
+			assert.Equal(t, expectBytes, buf.Bytes())
+		})
+	}
+}

--- a/src/service/v2/game_image_test.go
+++ b/src/service/v2/game_image_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -352,6 +353,198 @@ func TestGetGameImages(t *testing.T) {
 				assert.Equal(t, testCase.gameImages[i].GetType(), gameImage.GetType())
 				assert.Equal(t, testCase.gameImages[i].GetCreatedAt(), gameImage.GetCreatedAt())
 			}
+		})
+	}
+}
+
+func TestGetGameImage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mockRepository.NewMockDB(ctrl)
+	mockGameRepository := mockRepository.NewMockGame(ctrl)
+	mockGameImageRepository := mockRepository.NewMockGameImageV2(ctrl)
+	mockGameImageStorage := mockStorage.NewGameImage(ctrl, nil)
+
+	gameImageService := NewGameImage(
+		mockDB,
+		mockGameRepository,
+		mockGameImageRepository,
+		mockGameImageStorage,
+	)
+
+	type test struct {
+		description         string
+		gameID              values.GameID
+		gameImageID         values.GameImageID
+		getGameErr          error
+		executeGetGameImage bool
+		image               *repository.GameImageInfo
+		getGameImageErr     error
+		executeGetTempURL   bool
+		imageURL            values.GameImageTmpURL
+		getTempURLErr       error
+		isErr               bool
+		err                 error
+	}
+
+	urlLink, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatalf("failed to encode image: %v", err)
+	}
+
+	gameID1 := values.NewGameID()
+	gameID2 := values.NewGameID()
+	gameID3 := values.NewGameID()
+	gameID4 := values.NewGameID()
+
+	testCases := []test{
+		{
+			description:         "特に問題ないのでエラーなし",
+			gameID:              gameID1,
+			executeGetGameImage: true,
+			image: &repository.GameImageInfo{
+				GameImage: domain.NewGameImage(
+					values.NewGameImageID(),
+					values.GameImageTypeJpeg,
+					time.Now(),
+				),
+				GameID: gameID1,
+			},
+			executeGetTempURL: true,
+			imageURL:          values.NewGameImageTmpURL(urlLink),
+		},
+		{
+			description: "GetGameがErrRecordNotFoundなのでErrInvalidGameID",
+			gameID:      values.NewGameID(),
+			getGameErr:  repository.ErrRecordNotFound,
+			isErr:       true,
+			err:         service.ErrInvalidGameID,
+		},
+		{
+			description: "GetGameがエラーなのでエラー",
+			gameID:      values.NewGameID(),
+			getGameErr:  errors.New("error"),
+			isErr:       true,
+		},
+		{
+			description:         "画像がpngでもエラーなし",
+			gameID:              gameID2,
+			executeGetGameImage: true,
+			image: &repository.GameImageInfo{
+				GameImage: domain.NewGameImage(
+					values.NewGameImageID(),
+					values.GameImageTypePng,
+					time.Now(),
+				),
+				GameID: gameID2,
+			},
+			executeGetTempURL: true,
+		},
+		{
+			description:         "画像がgifでもエラーなし",
+			gameID:              gameID3,
+			executeGetGameImage: true,
+			image: &repository.GameImageInfo{
+				GameImage: domain.NewGameImage(
+					values.NewGameImageID(),
+					values.GameImageTypeGif,
+					time.Now(),
+				),
+				GameID: gameID3,
+			},
+			executeGetTempURL: true,
+		},
+		{
+			description:         "GetGameImageがErrRecordNotFoundなのでErrInvalidGameImageID",
+			gameID:              values.NewGameID(),
+			executeGetGameImage: true,
+			getGameImageErr:     repository.ErrRecordNotFound,
+			isErr:               true,
+			err:                 service.ErrInvalidGameImageID,
+		},
+		{
+			description:         "ゲーム画像に紐づくゲームIDが違うのでErrInvalidGameImageID",
+			gameID:              values.NewGameID(),
+			executeGetGameImage: true,
+			image: &repository.GameImageInfo{
+				GameImage: domain.NewGameImage(
+					values.NewGameImageID(),
+					values.GameImageTypeGif,
+					time.Now(),
+				),
+				GameID: values.NewGameID(),
+			},
+			isErr: true,
+			err:   service.ErrInvalidGameImageID,
+		},
+		{
+			description:         "GetGameImageがエラーなのでエラー",
+			gameID:              values.NewGameID(),
+			executeGetGameImage: true,
+			getGameImageErr:     errors.New("error"),
+			isErr:               true,
+		},
+		{
+			description:         "GetTempURLがエラーなのでエラー",
+			gameID:              gameID4,
+			executeGetGameImage: true,
+			image: &repository.GameImageInfo{
+				GameImage: domain.NewGameImage(
+					values.NewGameImageID(),
+					values.GameImageTypeJpeg,
+					time.Now(),
+				),
+				GameID: gameID4,
+			},
+			executeGetTempURL: true,
+			imageURL:          values.NewGameImageTmpURL(urlLink),
+			getTempURLErr:     errors.New("error"),
+			isErr:             true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			mockGameRepository.
+				EXPECT().
+				GetGame(ctx, testCase.gameID, repository.LockTypeNone).
+				Return(nil, testCase.getGameErr)
+
+			if testCase.executeGetGameImage {
+				mockGameImageRepository.
+					EXPECT().
+					GetGameImage(ctx, testCase.gameImageID, repository.LockTypeRecord).
+					Return(testCase.image, testCase.getGameImageErr)
+			}
+
+			if testCase.executeGetTempURL {
+				mockGameImageStorage.
+					EXPECT().
+					GetTempURL(ctx, testCase.image.GameImage, time.Minute).
+					Return(testCase.imageURL, testCase.getTempURLErr)
+			}
+
+			tmpURL, err := gameImageService.GetGameImage(ctx, testCase.gameID, testCase.gameImageID)
+
+			if testCase.isErr {
+				if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, testCase.imageURL, tmpURL)
 		})
 	}
 }

--- a/src/service/v2_game_image.go
+++ b/src/service/v2_game_image.go
@@ -22,7 +22,8 @@ type GameImageV2 interface {
 	// GetGameImage
 	// ゲーム画像の一時的(1分間)に有効なurlを返す。
 	// ゲームIDに対応するゲームが存在しない場合、ErrInvalidGameIDを返す。
-	// ゲーム画像IDに対応するゲーム画像が存在しない場合、ErrInvalidGameImageIDを返す。
+	// ゲーム画像IDに対応するゲーム画像が存在しない、
+	// もしくは存在しても紐づくゲームのゲームIDが異なる場合、ErrInvalidGameImageIDを返す。
 	GetGameImage(ctx context.Context, gameID values.GameID, imageID values.GameImageID) (values.GameImageTmpURL, error)
 	// GetGameImageMeta
 	// ゲーム画像のメタデータの取得。

--- a/src/service/v2_game_image.go
+++ b/src/service/v2_game_image.go
@@ -1,0 +1,32 @@
+package service
+
+//go:generate go run github.com/golang/mock/mockgen -source=$GOFILE -destination=mock/${GOFILE} -package=mock
+
+import (
+	"context"
+	"io"
+
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
+
+type GameImageV2 interface {
+	// SaveGameImage
+	// ゲーム画像の保存。
+	// ゲームIDに対応するゲームが存在しない場合、ErrInvalidGameIDを返す。
+	SaveGameImage(ctx context.Context, reader io.Reader, gameID values.GameID) error
+	// GetGameImage
+	// ゲーム画像一覧の取得。
+	// ゲームIDに対応するゲームが存在しない場合、ErrInvalidGameIDを返す。
+	GetGameImages(ctx context.Context, gameID values.GameID) ([]*domain.GameImage, error)
+	// GetGameImage
+	// ゲーム画像の一時的(1分間)に有効なurlを返す。
+	// ゲームIDに対応するゲームが存在しない場合、ErrInvalidGameIDを返す。
+	// ゲーム画像IDに対応するゲーム画像が存在しない場合、ErrInvalidGameImageIDを返す。
+	GetGameImage(ctx context.Context, gameID values.GameID, imageID values.GameImageID) (values.GameImageTmpURL, error)
+	// GetGameImageMeta
+	// ゲーム画像のメタデータの取得。
+	// ゲームIDに対応するゲームが存在しない場合、ErrInvalidGameIDを返す。
+	// ゲーム画像IDに対応するゲーム画像が存在しない場合、ErrInvalidGameImageIDを返す。
+	GetGameImageMeta(ctx context.Context, gameID values.GameID, imageID values.GameImageID) (*domain.GameImage, error)
+}


### PR DESCRIPTION
実装した。
GameRepositoryに関しては実装すると#432 とコンフリクトするため、一旦v1のものを使っている。
v1、v2でほとんど挙動に変わりはないはずなので、おそらくv2のGameRepositoryが実装され次第置き換えるだけで問題ない。