### PR TITLE
s3実装をvirtual hosted styleに変更

### DIFF
--- a/docker/base/compose.yaml
+++ b/docker/base/compose.yaml
@@ -56,3 +56,7 @@ services:
       timeout: 5m
       interval: 1s
       retries: 1000
+    networks:
+      default:
+        aliases:
+          - trap-collection.s3

--- a/src/storage/s3/client.go
+++ b/src/storage/s3/client.go
@@ -88,9 +88,7 @@ func setupS3(
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	client := s3.NewFromConfig(cfg, func(option *s3.Options) {
-		option.UsePathStyle = true
-	})
+	client := s3.NewFromConfig(cfg)
 
 	return client, nil
 }


### PR DESCRIPTION
path styleは廃止予定らしいのでvirtual hosted styleに変更した。
これに伴い、test用のdocker composeでminioにサブドメインでも接続できるようにする必要があったのでその対応もしている。
ref: https://aws.amazon.com/jp/blogs/news/amazon-s3-path-deprecation-plan-the-rest-of-the-story/