### PR TITLE
ゲーム画像関連のhandler実装

### DIFF
--- a/src/handler/v2/api.go
+++ b/src/handler/v2/api.go
@@ -101,6 +101,11 @@ func (api *API) setRoutes(e *echo.Echo) error {
 		Options: openapi3filter.Options{
 			MultiError:         true,
 			AuthenticationFunc: api.Checker.check,
+			// validate時にデータがメモリに乗るため、
+			// 画像・動画・ファイルのような大きなデータのアップロード時にメモリ不足にならないように、
+			// ExcludeRequestBody、ExcludeResponseBodyをtrueにする
+			ExcludeRequestBody:  true,
+			ExcludeResponseBody: true,
 		},
 	}))
 	openapi.RegisterHandlersWithBaseURL(apiGroup, api, "/api/v2")

--- a/src/handler/v2/game_image.go
+++ b/src/handler/v2/game_image.go
@@ -1,7 +1,12 @@
 package v2
 
 import (
+	"errors"
+	"log"
+	"net/http"
+
 	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v2/openapi"
 	"github.com/traPtitech/trap-collection-server/src/service"
 )
@@ -21,9 +26,6 @@ func NewGameImage(gameImageService service.GameImageV2) *GameImage {
 // メソッドとして実装予定だが、未実装のもの
 // TODO: 実装
 type gameImageUnimplemented interface {
-	// ゲーム画像の作成
-	// (GET /games/{gameID}/images)
-	GetGameImages(ctx echo.Context, gameID openapi.GameIDInPath) error
 	// ゲーム画像一覧の取得
 	// (POST /games/{gameID}/images)
 	PostGameImage(ctx echo.Context, gameID openapi.GameIDInPath) error
@@ -33,4 +35,41 @@ type gameImageUnimplemented interface {
 	// ゲーム画像のメタ情報の取得
 	// (GET /games/{gameID}/images/{gameImageID}/meta)
 	GetGameImageMeta(ctx echo.Context, gameID openapi.GameIDInPath, gameImageID openapi.GameImageIDInPath) error
+}
+
+// ゲーム画像一覧の取得
+// (GET /games/{gameID}/images)
+func (gameImage *GameImage) GetGameImages(c echo.Context, gameID openapi.GameIDInPath) error {
+	images, err := gameImage.gameImageService.GetGameImages(c.Request().Context(), values.NewGameIDFromUUID(gameID))
+	if errors.Is(err, service.ErrInvalidGameID) {
+		return echo.NewHTTPError(http.StatusNotFound, "invalid gameID")
+	}
+	if err != nil {
+		log.Printf("error: failed to get game images: %v\n", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get game images")
+	}
+
+	resImages := make([]openapi.GameImage, 0, len(images))
+	for _, image := range images {
+		var mime openapi.GameImageMime
+		switch image.GetType() {
+		case values.GameImageTypeJpeg:
+			mime = openapi.Imagejpeg
+		case values.GameImageTypePng:
+			mime = openapi.Imagepng
+		case values.GameImageTypeGif:
+			mime = openapi.Imagegif
+		default:
+			log.Printf("error: unknown game image type: %v\n", image.GetType())
+			return echo.NewHTTPError(http.StatusInternalServerError, "unknown game image type")
+		}
+
+		resImages = append(resImages, openapi.GameImage{
+			Id:        openapi.GameImageID(image.GetID()),
+			Mime:      mime,
+			CreatedAt: image.GetCreatedAt(),
+		})
+	}
+
+	return c.JSON(http.StatusOK, resImages)
 }

--- a/src/handler/v2/game_image.go
+++ b/src/handler/v2/game_image.go
@@ -13,7 +13,6 @@ import (
 )
 
 type GameImage struct {
-	gameImageUnimplemented
 	gameImageService service.GameImageV2
 }
 
@@ -21,12 +20,6 @@ func NewGameImage(gameImageService service.GameImageV2) *GameImage {
 	return &GameImage{
 		gameImageService: gameImageService,
 	}
-}
-
-// gameImageUnimplemented
-// メソッドとして実装予定だが、未実装のもの
-// TODO: 実装
-type gameImageUnimplemented interface {
 }
 
 // ゲーム画像一覧の取得

--- a/src/handler/v2/game_image_test.go
+++ b/src/handler/v2/game_image_test.go
@@ -1,0 +1,217 @@
+package v2
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/trap-collection-server/src/domain"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/handler/v2/openapi"
+	"github.com/traPtitech/trap-collection-server/src/service"
+	"github.com/traPtitech/trap-collection-server/src/service/mock"
+)
+
+func TestGetGameImages(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGameImageService := mock.NewMockGameImageV2(ctrl)
+
+	gameImage := NewGameImage(mockGameImageService)
+
+	type test struct {
+		description      string
+		gameID           openapi.GameIDInPath
+		images           []*domain.GameImage
+		getGameImagesErr error
+		resImages        []openapi.GameImage
+		isErr            bool
+		err              error
+		statusCode       int
+	}
+
+	gameImageID1 := values.NewGameImageID()
+	gameImageID2 := values.NewGameImageID()
+	gameImageID3 := values.NewGameImageID()
+	gameImageID4 := values.NewGameImageID()
+	gameImageID5 := values.NewGameImageID()
+
+	now := time.Now()
+	testCases := []test{
+		{
+			description: "特に問題ないのでエラーなし",
+			gameID:      uuid.UUID(values.NewGameID()),
+			images: []*domain.GameImage{
+				domain.NewGameImage(
+					gameImageID1,
+					values.GameImageTypeJpeg,
+					now,
+				),
+			},
+			resImages: []openapi.GameImage{
+				{
+					Id:        uuid.UUID(gameImageID1),
+					Mime:      openapi.Imagejpeg,
+					CreatedAt: now,
+				},
+			},
+		},
+		{
+			description: "pngでもエラーなし",
+			gameID:      uuid.UUID(values.NewGameID()),
+			images: []*domain.GameImage{
+				domain.NewGameImage(
+					gameImageID2,
+					values.GameImageTypePng,
+					now,
+				),
+			},
+			resImages: []openapi.GameImage{
+				{
+					Id:        uuid.UUID(gameImageID2),
+					Mime:      openapi.Imagepng,
+					CreatedAt: now,
+				},
+			},
+		},
+		{
+			description: "gifでもエラーなし",
+			gameID:      uuid.UUID(values.NewGameID()),
+			images: []*domain.GameImage{
+				domain.NewGameImage(
+					gameImageID3,
+					values.GameImageTypeGif,
+					now,
+				),
+			},
+			resImages: []openapi.GameImage{
+				{
+					Id:        uuid.UUID(gameImageID3),
+					Mime:      openapi.Imagegif,
+					CreatedAt: now,
+				},
+			},
+		},
+		{
+			description: "jpeg,png,gifのいずれでもないので500",
+			gameID:      uuid.UUID(values.NewGameID()),
+			images: []*domain.GameImage{
+				domain.NewGameImage(
+					values.NewGameImageID(),
+					values.GameImageType(100),
+					now,
+				),
+			},
+			isErr:      true,
+			statusCode: http.StatusInternalServerError,
+		},
+		{
+			description:      "GetGameImagesがErrInvalidGameIDなので404",
+			gameID:           uuid.UUID(values.NewGameID()),
+			getGameImagesErr: service.ErrInvalidGameID,
+			isErr:            true,
+			statusCode:       http.StatusNotFound,
+		},
+		{
+			description:      "GetGameImagesがエラーなので500",
+			gameID:           uuid.UUID(values.NewGameID()),
+			getGameImagesErr: errors.New("error"),
+			isErr:            true,
+			statusCode:       http.StatusInternalServerError,
+		},
+		{
+			description: "画像がなくても問題なし",
+			gameID:      uuid.UUID(values.NewGameID()),
+			images:      []*domain.GameImage{},
+			resImages:   []openapi.GameImage{},
+		},
+		{
+			description: "画像が複数あっても問題なし",
+			gameID:      uuid.UUID(values.NewGameID()),
+			images: []*domain.GameImage{
+				domain.NewGameImage(
+					gameImageID4,
+					values.GameImageTypeJpeg,
+					now,
+				),
+				domain.NewGameImage(
+					gameImageID5,
+					values.GameImageTypePng,
+					now.Add(-10*time.Hour),
+				),
+			},
+			resImages: []openapi.GameImage{
+				{
+					Id:        uuid.UUID(gameImageID4),
+					Mime:      openapi.Imagejpeg,
+					CreatedAt: now,
+				},
+				{
+					Id:        uuid.UUID(gameImageID5),
+					Mime:      openapi.Imagepng,
+					CreatedAt: now.Add(-10 * time.Hour),
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/games/%s/images", testCase.gameID), nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			mockGameImageService.
+				EXPECT().
+				GetGameImages(gomock.Any(), gomock.Any()).
+				Return(testCase.images, testCase.getGameImagesErr)
+
+			err := gameImage.GetGameImages(c, testCase.gameID)
+
+			if testCase.isErr {
+				if testCase.statusCode != 0 {
+					var httpError *echo.HTTPError
+					if errors.As(err, &httpError) {
+						assert.Equal(t, testCase.statusCode, httpError.Code)
+					} else {
+						t.Errorf("error is not *echo.HTTPError")
+					}
+				} else if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil || testCase.isErr {
+				return
+			}
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var resImages []openapi.GameImage
+			err = json.NewDecoder(rec.Body).Decode(&resImages)
+			if err != nil {
+				t.Fatalf("failed to decode response body: %v", err)
+			}
+			for i, resImage := range resImages {
+				assert.Equal(t, testCase.resImages[i].Id, resImage.Id)
+				assert.Equal(t, testCase.resImages[i].Mime, resImage.Mime)
+				assert.WithinDuration(t, testCase.resImages[i].CreatedAt, resImage.CreatedAt, time.Second)
+			}
+		})
+	}
+}

--- a/src/service/v2/game_image.go
+++ b/src/service/v2/game_image.go
@@ -41,7 +41,8 @@ func NewGameImage(
 	}
 }
 
-func (gameImage *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, gameID values.GameID) error {
+func (gameImage *GameImage) SaveGameImage(ctx context.Context, reader io.Reader, gameID values.GameID) (*domain.GameImage, error) {
+	var image *domain.GameImage
 	err := gameImage.db.Transaction(ctx, nil, func(ctx context.Context) error {
 		// TODO: v2のgameRepositoryに変更
 		_, err := gameImage.gameRepository.GetGame(ctx, gameID, repository.LockTypeRecord)
@@ -83,7 +84,7 @@ func (gameImage *GameImage) SaveGameImage(ctx context.Context, reader io.Reader,
 				return service.ErrInvalidFormat
 			}
 
-			image := domain.NewGameImage(
+			image = domain.NewGameImage(
 				imageID,
 				imageType,
 				time.Now(),
@@ -129,10 +130,10 @@ func (gameImage *GameImage) SaveGameImage(ctx context.Context, reader io.Reader,
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed in transaction: %w", err)
+		return nil, fmt.Errorf("failed in transaction: %w", err)
 	}
 
-	return nil
+	return image, nil
 }
 
 func (gameImage *GameImage) GetGameImages(ctx context.Context, gameID values.GameID) ([]*domain.GameImage, error) {

--- a/src/service/v2/game_image_test.go
+++ b/src/service/v2/game_image_test.go
@@ -192,7 +192,7 @@ func TestSaveGameImage(t *testing.T) {
 					Return(testCase.StorageSaveGameImageErr)
 			}
 
-			err := gameImageService.SaveGameImage(ctx, file, testCase.gameID)
+			image, err := gameImageService.SaveGameImage(ctx, file, testCase.gameID)
 
 			if testCase.isErr {
 				if testCase.err == nil {
@@ -206,6 +206,9 @@ func TestSaveGameImage(t *testing.T) {
 			if err != nil || testCase.isErr {
 				return
 			}
+
+			assert.Equal(t, testCase.imageType, image.GetType())
+			assert.WithinDuration(t, time.Now(), image.GetCreatedAt(), time.Second)
 
 			assert.Equal(t, expectBytes, buf.Bytes())
 		})

--- a/src/service/v2_game_image.go
+++ b/src/service/v2_game_image.go
@@ -14,7 +14,7 @@ type GameImageV2 interface {
 	// SaveGameImage
 	// ゲーム画像の保存。
 	// ゲームIDに対応するゲームが存在しない場合、ErrInvalidGameIDを返す。
-	SaveGameImage(ctx context.Context, reader io.Reader, gameID values.GameID) error
+	SaveGameImage(ctx context.Context, reader io.Reader, gameID values.GameID) (*domain.GameImage, error)
 	// GetGameImage
 	// ゲーム画像一覧の取得。
 	// ゲームIDに対応するゲームが存在しない場合、ErrInvalidGameIDを返す。

--- a/src/wire/repository.go
+++ b/src/wire/repository.go
@@ -41,4 +41,7 @@ var repositorySet = wire.NewSet(
 
 	wire.Bind(new(repository.LauncherVersion), new(*gorm2.LauncherVersion)),
 	gorm2.NewLauncherVersion,
+
+	wire.Bind(new(repository.GameImageV2), new(*gorm2.GameImageV2)),
+	gorm2.NewGameImageV2,
 )

--- a/src/wire/service.go
+++ b/src/wire/service.go
@@ -57,6 +57,9 @@ var (
 		wire.Bind(new(service.OIDCV2), new(*v2.OIDC)),
 		v2.NewOIDC,
 
+		wire.Bind(new(service.GameImageV2), new(*v2.GameImage)),
+		v2.NewGameImage,
+
 		v2.NewUser,
 	)
 )

--- a/src/wire/wire_gen.go
+++ b/src/wire/wire_gen.go
@@ -196,12 +196,14 @@ func InjectApp() (*App, error) {
 	v2GameRole := v2.NewGameRole()
 	v2GameVersion := v2.NewGameVersion()
 	v2GameFile := v2.NewGameFile()
-	v2GameImage := v2.NewGameImage()
+	gameImageV2 := gorm2.NewGameImageV2(db)
+	v2GameImage := v2_2.NewGameImage(db, game, gameImageV2, storageGameImage)
+	gameImage3 := v2.NewGameImage(v2GameImage)
 	v2GameVideo := v2.NewGameVideo()
 	edition := v2.NewEdition()
 	editionAuth := v2.NewEditionAuth()
 	seat := v2.NewSeat()
-	v2API := v2.NewAPI(checker, v2Session, v2OAuth2, user3, admin, v2Game, v2GameRole, v2GameVersion, v2GameFile, v2GameImage, v2GameVideo, edition, editionAuth, seat)
+	v2API := v2.NewAPI(checker, v2Session, v2OAuth2, user3, admin, v2Game, v2GameRole, v2GameVersion, v2GameFile, gameImage3, v2GameVideo, edition, editionAuth, seat)
 	handlerAPI, err := handler.NewAPI(app, v1Handler, session, api, v2API)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
実装した。
oapi-codegenで画像データ周りのバリデーション時にデータが全てメモリにのることがわかったので、`ExcludeRequestBody`、`ExcludeResponseBody`を有効にしてバリデーションを切っている。