### PR TITLE
Game関連のAPIでSQL文を適切に修正

### DIFF
--- a/src/repository/errors.go
+++ b/src/repository/errors.go
@@ -3,9 +3,8 @@ package repository
 import "errors"
 
 var (
-	ErrRecordNotFound    = errors.New("record not found")
-	ErrNoRecordDeleted   = errors.New("no record deleted")
-	ErrNoRecordUpdated   = errors.New("no record updated")
-	ErrNegativeLimit     = errors.New("limit is negative")
-	ErrBadLimitAndOffset = errors.New("Limit and Offset are invalid")
+	ErrRecordNotFound  = errors.New("record not found")
+	ErrNoRecordDeleted = errors.New("no record deleted")
+	ErrNoRecordUpdated = errors.New("no record updated")
+	ErrNegativeLimit   = errors.New("limit is negative")
 )

--- a/src/repository/errors.go
+++ b/src/repository/errors.go
@@ -3,8 +3,10 @@ package repository
 import "errors"
 
 var (
-	ErrRecordNotFound  = errors.New("record not found")
-	ErrNoRecordDeleted = errors.New("no record deleted")
-	ErrNoRecordUpdated = errors.New("no record updated")
-	ErrNegativeLimit   = errors.New("limit is smaller than -1")
+	ErrRecordNotFound     = errors.New("record not found")
+	ErrNoRecordDeleted    = errors.New("no record deleted")
+	ErrNoRecordUpdated    = errors.New("no record updated")
+	ErrNegativeLimit      = errors.New("limit is negative")
+	ErrOffsetWithoutLimit = errors.New("there is offset but no limit")
+	ErrBadLimitAndOffset  = errors.New("Limit and Offset are invalid")
 )

--- a/src/repository/errors.go
+++ b/src/repository/errors.go
@@ -3,10 +3,9 @@ package repository
 import "errors"
 
 var (
-	ErrRecordNotFound     = errors.New("record not found")
-	ErrNoRecordDeleted    = errors.New("no record deleted")
-	ErrNoRecordUpdated    = errors.New("no record updated")
-	ErrNegativeLimit      = errors.New("limit is negative")
-	ErrOffsetWithoutLimit = errors.New("there is offset but no limit")
-	ErrBadLimitAndOffset  = errors.New("Limit and Offset are invalid")
+	ErrRecordNotFound    = errors.New("record not found")
+	ErrNoRecordDeleted   = errors.New("no record deleted")
+	ErrNoRecordUpdated   = errors.New("no record updated")
+	ErrNegativeLimit     = errors.New("limit is negative")
+	ErrBadLimitAndOffset = errors.New("Limit and Offset are invalid")
 )

--- a/src/repository/gorm2/v2_game.go
+++ b/src/repository/gorm2/v2_game.go
@@ -162,7 +162,9 @@ func (g *GameV2) GetGames(ctx context.Context, limit int, offset int) ([]*domain
 	}
 
 	var gamesNumber int64
-	err = db.Table("games").Count(&gamesNumber).Error
+	err = db.Table("games").
+		Where("deleted_at IS NULL").
+		Count(&gamesNumber).Error
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get games number: %w", err)
 	}

--- a/src/repository/gorm2/v2_game.go
+++ b/src/repository/gorm2/v2_game.go
@@ -176,24 +176,32 @@ func (g *GameV2) GetGamesByUser(ctx context.Context, userID values.TraPMemberID,
 		return nil, 0, fmt.Errorf("failed to get db: %w", err)
 	}
 
-	var allUserGames []migrate.GameTable2
-	err = db.
-		Joins("JOIN game_management_roles ON game_management_roles.game_id = games.id").
-		Where("game_management_roles.user_id = ?", uuid.UUID(userID)).
-		Order("created_at DESC").
-		Find(&allUserGames).Error
-
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get games: %w", err)
-	}
-
 	var games []migrate.GameTable2
-	if limit == 0 {
-		games = allUserGames[offset:]
+
+	if limit == 0 && offset == 0 { //offsetだけを設定するのはserviceで止めているが、ここでも一応
+		err = db.
+			Joins("JOIN game_management_roles ON game_management_roles.game_id = games.id").
+			Where("game_management_roles.user_id = ?", uuid.UUID(userID)).
+			Order("created_at DESC").
+			Find(&games).Error
+	} else if limit > 0 {
+		err = db.
+			Joins("JOIN game_management_roles ON game_management_roles.game_id = games.id").
+			Where("game_management_roles.user_id = ?", uuid.UUID(userID)).
+			Order("created_at DESC").
+			Limit(limit).
+			Offset(offset).
+			Find(&games).Error
+	} else if limit == 0 && offset > 0 {
+		return nil, 0, repository.ErrOffsetWithoutLimit
 	} else if limit < 0 {
 		return nil, 0, repository.ErrNegativeLimit
 	} else {
-		games = allUserGames[offset : offset+limit]
+		return nil, 0, repository.ErrBadLimitAndOffset
+	}
+
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get games: %w", err)
 	}
 
 	gamesDomain := make([]*domain.Game, 0, len(games))
@@ -206,5 +214,16 @@ func (g *GameV2) GetGamesByUser(ctx context.Context, userID values.TraPMemberID,
 		))
 	}
 
-	return gamesDomain, len(allUserGames), nil
+	var gameNumber int64
+	err = db.
+		Table("games").
+		Joins("JOIN game_management_roles ON game_management_roles.game_id = games.id").
+		Where("game_management_roles.user_id = ?", uuid.UUID(userID)).
+		Where("deleted_at IS NULL").
+		Count(&gameNumber).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get games number: %w", err)
+	}
+
+	return gamesDomain, int(gameNumber), nil
 }

--- a/src/repository/gorm2/v2_game.go
+++ b/src/repository/gorm2/v2_game.go
@@ -188,8 +188,11 @@ func (g *GameV2) GetGamesByUser(ctx context.Context, userID values.TraPMemberID,
 
 	var games []migrate.GameTable2
 
-	query := db.Joins("JOIN game_management_roles ON game_management_roles.game_id = games.id").
+	tx := db.Joins("JOIN game_management_roles ON game_management_roles.game_id = games.id").
 		Where("game_management_roles.user_id = ?", uuid.UUID(userID)).
+		Session(&gorm.Session{})
+
+	query := tx.
 		Order("created_at DESC")
 
 	if limit > 0 {
@@ -217,10 +220,9 @@ func (g *GameV2) GetGamesByUser(ctx context.Context, userID values.TraPMemberID,
 	}
 
 	var gameNumber int64
-	err = db.
+
+	err = tx.
 		Table("games").
-		Joins("JOIN game_management_roles ON game_management_roles.game_id = games.id").
-		Where("game_management_roles.user_id = ?", uuid.UUID(userID)).
 		Where("deleted_at IS NULL").
 		Count(&gameNumber).Error
 	if err != nil {

--- a/src/repository/gorm2/v2_game.go
+++ b/src/repository/gorm2/v2_game.go
@@ -129,23 +129,27 @@ func (g *GameV2) GetGames(ctx context.Context, limit int, offset int) ([]*domain
 
 	var games []migrate.GameTable2
 
-	if limit == 0 && offset == 0 { //offsetだけを設定するのはserviceで止めているが、ここでも一応
-		err = db.
-			Order("created_at DESC").
-			Find(&games).Error
-	} else if limit > 0 {
-		err = db.
-			Order("created_at DESC").
-			Limit(limit).
-			Offset(offset).
-			Find(&games).Error
-	} else if limit == 0 && offset > 0 {
-		return nil, 0, repository.ErrOffsetWithoutLimit
-	} else if limit < 0 {
+	var lim int
+	var off int
+
+	switch {
+	case limit == 0 && offset == 0:
+		lim = -1
+		off = 0
+	case limit > 0 && offset >= 0:
+		lim = limit
+		off = offset
+	case limit < 0:
 		return nil, 0, repository.ErrNegativeLimit
-	} else {
+	default:
 		return nil, 0, repository.ErrBadLimitAndOffset
 	}
+
+	err = db.
+		Order("created_at DESC").
+		Limit(lim).
+		Offset(off).
+		Find(&games).Error
 
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get games: %w", err)
@@ -180,27 +184,29 @@ func (g *GameV2) GetGamesByUser(ctx context.Context, userID values.TraPMemberID,
 
 	var games []migrate.GameTable2
 
-	if limit == 0 && offset == 0 { //offsetだけを設定するのはserviceで止めているが、ここでも一応
-		err = db.
-			Joins("JOIN game_management_roles ON game_management_roles.game_id = games.id").
-			Where("game_management_roles.user_id = ?", uuid.UUID(userID)).
-			Order("created_at DESC").
-			Find(&games).Error
-	} else if limit > 0 {
-		err = db.
-			Joins("JOIN game_management_roles ON game_management_roles.game_id = games.id").
-			Where("game_management_roles.user_id = ?", uuid.UUID(userID)).
-			Order("created_at DESC").
-			Limit(limit).
-			Offset(offset).
-			Find(&games).Error
-	} else if limit == 0 && offset > 0 {
-		return nil, 0, repository.ErrOffsetWithoutLimit
-	} else if limit < 0 {
+	var lim int
+	var off int
+
+	switch {
+	case limit == 0 && offset == 0:
+		lim = -1
+		off = 0
+	case limit > 0 && offset >= 0:
+		lim = limit
+		off = offset
+	case limit < 0:
 		return nil, 0, repository.ErrNegativeLimit
-	} else {
+	default:
 		return nil, 0, repository.ErrBadLimitAndOffset
 	}
+
+	err = db.
+		Joins("JOIN game_management_roles ON game_management_roles.game_id = games.id").
+		Where("game_management_roles.user_id = ?", uuid.UUID(userID)).
+		Order("created_at DESC").
+		Limit(lim).
+		Offset(off).
+		Find(&games).Error
 
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get games: %w", err)

--- a/src/repository/gorm2/v2_game.go
+++ b/src/repository/gorm2/v2_game.go
@@ -142,7 +142,7 @@ func (g *GameV2) GetGames(ctx context.Context, limit int, offset int) ([]*domain
 	case limit < 0:
 		return nil, 0, repository.ErrNegativeLimit
 	default:
-		return nil, 0, repository.ErrBadLimitAndOffset
+		return nil, 0, errors.New("bad limit and offset")
 	}
 
 	err = db.
@@ -197,7 +197,7 @@ func (g *GameV2) GetGamesByUser(ctx context.Context, userID values.TraPMemberID,
 	case limit < 0:
 		return nil, 0, repository.ErrNegativeLimit
 	default:
-		return nil, 0, repository.ErrBadLimitAndOffset
+		return nil, 0, errors.New("bad limit and offset")
 	}
 
 	err = db.

--- a/src/repository/gorm2/v2_game_test.go
+++ b/src/repository/gorm2/v2_game_test.go
@@ -747,7 +747,7 @@ func TestGetGamesV2(t *testing.T) {
 				},
 			},
 			isErr: true,
-			err:   repository.ErrOffsetWithoutLimit,
+			err:   repository.ErrBadLimitAndOffset,
 		},
 		{
 			description: "limitとoffset両方が設定されてもエラーなし",
@@ -1171,7 +1171,7 @@ func TestGetGamesByUserV2(t *testing.T) {
 				},
 			},
 			isErr: true,
-			err:   repository.ErrOffsetWithoutLimit,
+			err:   repository.ErrBadLimitAndOffset,
 		},
 		{
 			description: "limitとoffset両方設定してもエラーなし",

--- a/src/repository/gorm2/v2_game_test.go
+++ b/src/repository/gorm2/v2_game_test.go
@@ -729,7 +729,7 @@ func TestGetGamesV2(t *testing.T) {
 			},
 		},
 		{
-			description: "offsetだけなのでエラー",
+			description: "offsetだけなのでエラー", //これはserviceで除かれるはず
 			limit:       0,
 			offset:      1,
 			beforeGames: []migrate.GameTable2{
@@ -1060,7 +1060,7 @@ func TestGetGamesByUserV2(t *testing.T) {
 					ID:          uuid.UUID(gameID6),
 					Name:        "test6",
 					Description: "test6",
-					CreatedAt:   now,
+					CreatedAt:   now.Add(-time.Hour),
 					DeletedAt: gorm.DeletedAt{
 						Valid: true,
 						Time:  now,
@@ -1140,7 +1140,7 @@ func TestGetGamesByUserV2(t *testing.T) {
 			},
 		},
 		{
-			description: "offsetが設定されてもエラーなし",
+			description: "offsetだけなのでエラー", //これはserviceで除かれるはず
 			userID:      userID10,
 			limit:       0,
 			offset:      1,
@@ -1170,15 +1170,8 @@ func TestGetGamesByUserV2(t *testing.T) {
 					},
 				},
 			},
-			expectedGameNumber: 2,
-			games: []*domain.Game{
-				domain.NewGame(
-					gameID11,
-					"test11",
-					"test11",
-					now.Add(-time.Hour),
-				),
-			},
+			isErr: true,
+			err:   repository.ErrOffsetWithoutLimit,
 		},
 		{
 			description: "limitとoffset両方設定してもエラーなし",

--- a/src/repository/gorm2/v2_game_test.go
+++ b/src/repository/gorm2/v2_game_test.go
@@ -747,7 +747,6 @@ func TestGetGamesV2(t *testing.T) {
 				},
 			},
 			isErr: true,
-			err:   repository.ErrBadLimitAndOffset,
 		},
 		{
 			description: "limitとoffset両方が設定されてもエラーなし",
@@ -1171,7 +1170,6 @@ func TestGetGamesByUserV2(t *testing.T) {
 				},
 			},
 			isErr: true,
-			err:   repository.ErrBadLimitAndOffset,
 		},
 		{
 			description: "limitとoffset両方設定してもエラーなし",

--- a/src/repository/gorm2/v2_game_test.go
+++ b/src/repository/gorm2/v2_game_test.go
@@ -729,7 +729,7 @@ func TestGetGamesV2(t *testing.T) {
 			},
 		},
 		{
-			description: "offsetが設定されてもエラーなし",
+			description: "offsetだけなのでエラー",
 			limit:       0,
 			offset:      1,
 			beforeGames: []migrate.GameTable2{
@@ -746,14 +746,8 @@ func TestGetGamesV2(t *testing.T) {
 					CreatedAt:   now.Add(-time.Hour),
 				},
 			},
-			games: []*domain.Game{
-				domain.NewGame(
-					gameID2,
-					"test2",
-					"test2",
-					now.Add(-time.Hour),
-				),
-			},
+			isErr: true,
+			err:   repository.ErrOffsetWithoutLimit,
 		},
 		{
 			description: "limitとoffset両方が設定されてもエラーなし",

--- a/src/repository/v2_game.go
+++ b/src/repository/v2_game.go
@@ -31,7 +31,10 @@ type GameV2 interface {
 
 	//GetGames
 	//取得する個数の上限(limit)と開始位置(offset)を指定してゲームを取得する。
-	//上限なしはlimit=0。返り値のintは制限をかけないときのゲーム数で、エラーのときは0
+	//上限なしはlimit=0。返り値のintは制限をかけないときのゲーム数で、エラーのときは0。また、offsetのみを指定することはできない。
+	//limitが負のとき、ErrNegativeLimitを返す。
+	//offsetを指定してlimitを設定しなかったとき、ErrOffsetWithoutLimitを返すが、これはserviceで止める。
+	//それ以外limitとoffsetがまずかった場合、ErrBadLimitAndOffsetを返す。
 	GetGames(ctx context.Context, limit int, offset int) ([]*domain.Game, int, error)
 
 	//GetGamesByUser

--- a/src/repository/v2_game.go
+++ b/src/repository/v2_game.go
@@ -30,7 +30,7 @@ type GameV2 interface {
 	GetGame(ctx context.Context, gameID values.GameID, lockType LockType) (*domain.Game, error)
 
 	//GetGames
-	//取得する個数の上限(limit)と開始位置(offset)を指定してゲームを取得する。
+	//取得する個数の上限(limit>=0)と開始位置(offset>=0)を指定してゲームを取得する。
 	//上限なしはlimit=0。返り値のintは制限をかけないときのゲーム数で、エラーのときは0。また、offsetのみを指定することはできない。
 	//limitが負のとき、ErrNegativeLimitを返す。
 	//offsetを指定してlimitを設定しなかったとき、ErrOffsetWithoutLimitを返すが、これはserviceで止める。
@@ -39,6 +39,9 @@ type GameV2 interface {
 
 	//GetGamesByUser
 	//ユーザーのuuidと取得する個数の上限(limit)と開始位置(offset)を指定して、その人が作成したゲームを取得する。
-	//上限なしはlimit=0。返り値のintは制限をかけないときのその人が作ったゲーム数で、エラーのときは0
+	//上限なしはlimit=0。返り値のintは制限をかけないときのその人が作ったゲーム数で、エラーのときは0また、offsetのみを指定することはできない。
+	//limitが負のとき、ErrNegativeLimitを返す。
+	//offsetを指定してlimitを設定しなかったとき、ErrOffsetWithoutLimitを返すが、これはserviceで止める。
+	//それ以外limitとoffsetがまずかった場合、ErrBadLimitAndOffsetを返す。
 	GetGamesByUser(ctx context.Context, userID values.TraPMemberID, limit int, offset int) ([]*domain.Game, int, error)
 }

--- a/src/service/v2/game.go
+++ b/src/service/v2/game.go
@@ -220,6 +220,9 @@ func (g *Game) GetGames(ctx context.Context, limit int, offset int) (int, []*dom
 }
 
 func (g *Game) GetMyGames(ctx context.Context, session *domain.OIDCSession, limit int, offset int) (int, []*domain.Game, error) {
+	if limit == 0 && offset != 0 {
+		return 0, nil, service.ErrOffsetWithoutLimit
+	}
 	user, err := g.user.getMe(ctx, session)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to get user: %w", err)

--- a/src/service/v2/game.go
+++ b/src/service/v2/game.go
@@ -206,6 +206,9 @@ func (g *Game) GetGame(ctx context.Context, session *domain.OIDCSession, gameID 
 }
 
 func (g *Game) GetGames(ctx context.Context, limit int, offset int) (int, []*domain.Game, error) {
+	if limit == 0 && offset != 0 {
+		return 0, nil, service.ErrOffsetWithoutLimit
+	}
 	games, gameNumber, err := g.gameRepository.GetGames(ctx, limit, offset)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to get games: %w", err)

--- a/src/service/v2/game_test.go
+++ b/src/service/v2/game_test.go
@@ -969,10 +969,19 @@ func TestGetMyGames(t *testing.T) {
 		},
 		{
 			description: "offsetだけが設定されているのでエラー",
-			limit:       0,
-			offset:      1,
-			isErr:       true,
-			err:         service.ErrOffsetWithoutLimit,
+			authSession: domain.NewOIDCSession(
+				"access token",
+				time.Now().Add(time.Hour),
+			),
+			user: service.NewUserInfo(
+				values.NewTrapMemberID(uuid.New()),
+				"ikura-hamu",
+				values.TrapMemberStatusActive,
+			),
+			limit:  0,
+			offset: 1,
+			isErr:  true,
+			err:    service.ErrOffsetWithoutLimit,
 		},
 		{
 			description: "getMeがエラーなのでエラー",

--- a/src/service/v2/game_test.go
+++ b/src/service/v2/game_test.go
@@ -741,7 +741,7 @@ func TestGetGames(t *testing.T) {
 			n:      1,
 		},
 		{
-			description: "offsetが設定されてもエラーなし",
+			description: "limitとoffsetが両方設定されてもエラーなし",
 			games: []*domain.Game{
 				domain.NewGame(
 					gameID1,
@@ -750,10 +750,18 @@ func TestGetGames(t *testing.T) {
 					time.Now(),
 				),
 			},
-			limit:  0,
+			limit:  1,
 			offset: 1,
-			n:      1,
+			n:      2,
 		},
+		{
+			description: "offsetだけ設定されているのでエラー",
+			limit:       0,
+			offset:      1,
+			isErr:       true,
+			err:         service.ErrOffsetWithoutLimit,
+		},
+
 		{
 			description: "GetGamesがエラーなのでエラー",
 			GetGamesErr: errors.New("error"),
@@ -783,7 +791,8 @@ func TestGetGames(t *testing.T) {
 				return
 			}
 
-			assert.Len(t, games, n)
+			assert.Equal(t, testCase.n, n)
+			assert.Len(t, games, len(testCase.games))
 
 			for i, game := range games {
 				assert.Equal(t, testCase.games[i].GetID(), game.GetID())

--- a/src/service/v2/game_test.go
+++ b/src/service/v2/game_test.go
@@ -944,7 +944,7 @@ func TestGetMyGames(t *testing.T) {
 			n:      1,
 		},
 		{
-			description: "offsetが設定されてもエラーなし",
+			description: "limitとoffsetが両方設定されてもエラーなし",
 			authSession: domain.NewOIDCSession(
 				"access token",
 				time.Now().Add(time.Hour),
@@ -963,9 +963,16 @@ func TestGetMyGames(t *testing.T) {
 					time.Now(),
 				),
 			},
-			limit:  0,
+			limit:  1,
 			offset: 1,
 			n:      1,
+		},
+		{
+			description: "offsetだけが設定されているのでエラー",
+			limit:       0,
+			offset:      1,
+			isErr:       true,
+			err:         service.ErrOffsetWithoutLimit,
 		},
 		{
 			description: "getMeがエラーなのでエラー",
@@ -1033,7 +1040,8 @@ func TestGetMyGames(t *testing.T) {
 				return
 			}
 
-			assert.Len(t, games, n)
+			assert.Len(t, games, len(testCase.games))
+			assert.Equal(t, testCase.n, n)
 
 			for i, game := range games {
 				assert.Equal(t, testCase.games[i].GetID(), game.GetID())

--- a/src/service/v2/game_test.go
+++ b/src/service/v2/game_test.go
@@ -671,14 +671,15 @@ func TestGetGames(t *testing.T) {
 	)
 
 	type test struct {
-		description string
-		limit       int
-		offset      int
-		n           int
-		games       []*domain.Game
-		GetGamesErr error
-		isErr       bool
-		err         error
+		description     string
+		limit           int
+		offset          int
+		n               int
+		executeGetGames bool
+		games           []*domain.Game
+		GetGamesErr     error
+		isErr           bool
+		err             error
 	}
 
 	gameID1 := values.NewGameID()
@@ -695,16 +696,18 @@ func TestGetGames(t *testing.T) {
 					time.Now(),
 				),
 			},
-			limit:  0,
-			offset: 0,
-			n:      1,
+			executeGetGames: true,
+			limit:           0,
+			offset:          0,
+			n:               1,
 		},
 		{
-			description: "ゲームが存在しなくてもエラーなし",
-			games:       []*domain.Game{},
-			limit:       0,
-			offset:      0,
-			n:           0,
+			description:     "ゲームが存在しなくてもエラーなし",
+			games:           []*domain.Game{},
+			limit:           0,
+			offset:          0,
+			n:               0,
+			executeGetGames: true,
 		},
 		{
 			description: "ゲームが複数でもエラーなし",
@@ -722,9 +725,10 @@ func TestGetGames(t *testing.T) {
 					time.Now(),
 				),
 			},
-			limit:  0,
-			offset: 0,
-			n:      2,
+			limit:           0,
+			offset:          0,
+			n:               2,
+			executeGetGames: true,
 		},
 		{
 			description: "limitが設定されてもエラーなし",
@@ -736,9 +740,10 @@ func TestGetGames(t *testing.T) {
 					time.Now(),
 				),
 			},
-			limit:  1,
-			offset: 0,
-			n:      1,
+			limit:           1,
+			offset:          0,
+			n:               1,
+			executeGetGames: true,
 		},
 		{
 			description: "limitとoffsetが両方設定されてもエラーなし",
@@ -750,9 +755,10 @@ func TestGetGames(t *testing.T) {
 					time.Now(),
 				),
 			},
-			limit:  1,
-			offset: 1,
-			n:      2,
+			limit:           1,
+			offset:          1,
+			n:               2,
+			executeGetGames: true,
 		},
 		{
 			description: "offsetだけ設定されているのでエラー",
@@ -763,18 +769,21 @@ func TestGetGames(t *testing.T) {
 		},
 
 		{
-			description: "GetGamesがエラーなのでエラー",
-			GetGamesErr: errors.New("error"),
-			isErr:       true,
+			description:     "GetGamesがエラーなのでエラー",
+			GetGamesErr:     errors.New("error"),
+			isErr:           true,
+			executeGetGames: true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			mockGameRepository.
-				EXPECT().
-				GetGames(gomock.Any(), testCase.limit, testCase.offset).
-				Return(testCase.games, testCase.n, testCase.GetGamesErr)
+			if testCase.executeGetGames {
+				mockGameRepository.
+					EXPECT().
+					GetGames(gomock.Any(), testCase.limit, testCase.offset).
+					Return(testCase.games, testCase.n, testCase.GetGamesErr)
+			}
 
 			n, games, err := gameService.GetGames(ctx, testCase.limit, testCase.offset)
 

--- a/src/service/v2_errors.go
+++ b/src/service/v2_errors.go
@@ -6,4 +6,5 @@ var (
 	ErrOverlapBetweenOwnersAndMaintainers = errors.New("overlap between owners and maintainers")
 	ErrOverlapInOwners                    = errors.New("overlap (in owners/between login user and owners)")
 	ErrOverlapInMaintainers               = errors.New("overlap in maintainers")
+	ErrOffsetWithoutLimit                 = errors.New("there is offset but no limit")
 )


### PR DESCRIPTION
### 以前
全てのゲームを取得して、配列の長さから全ゲームの個数を、limit,offsetをかけて必要なゲームを取得していた。

### 今回
SQL文にLimitとOffsetをつけて必要なだけゲームを取得し、全ゲームの個数はCountを使って別途取得するようにした。