### PR TITLE
dev環境でbuildvcs=false設定

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -12,5 +12,7 @@ WORKDIR /go/src/github.com/traPtitech/trap-collection-server
 COPY go.mod go.sum ./
 RUN go mod download
 
+ENV GOFLAGS -buildvcs=false
+
 ENTRYPOINT ["go", "run", "github.com/cosmtrek/air"]
 CMD ["-c", ".air.toml"]


### PR DESCRIPTION
環境によってはdev環境のbuildvcs周りでエラーが出るようなので、offにした。