### PR TITLE
ゲームバージョンの実装ミス修正

### DIFF
--- a/src/handler/v2/game_version.go
+++ b/src/handler/v2/game_version.go
@@ -38,13 +38,18 @@ func (gameVersion *GameVersion) GetGameVersion(c echo.Context, gameID openapi.Ga
 		offset = uint(*params.Offset)
 	}
 
+	var param *service.GetGameVersionsParams
+	if limit != 0 || offset != 0 {
+		param = &service.GetGameVersionsParams{
+			Limit:  limit,
+			Offset: offset,
+		}
+	}
+
 	num, versions, err := gameVersion.gameVersionService.GetGameVersions(
 		c.Request().Context(),
 		values.NewGameIDFromUUID(gameID),
-		&service.GetGameVersionsParams{
-			Limit:  limit,
-			Offset: offset,
-		},
+		param,
 	)
 	if errors.Is(err, service.ErrInvalidGameID) {
 		return echo.NewHTTPError(http.StatusNotFound, "invalid gameID")

--- a/src/handler/v2/game_version_test.go
+++ b/src/handler/v2/game_version_test.go
@@ -38,8 +38,7 @@ func TestGetGameVersion(t *testing.T) {
 		gameID             values.GameID
 		limit              *int
 		offset             *int
-		expectLimit        uint
-		expectOffset       uint
+		expectParams       *service.GetGameVersionsParams
 		num                uint
 		gameVersions       []*service.GameVersionInfo
 		GetGameVersionErr  error
@@ -380,8 +379,10 @@ func TestGetGameVersion(t *testing.T) {
 			description: "limitが存在しても問題なし",
 			gameID:      gameID,
 			limit:       &one,
-			expectLimit: 1,
-			num:         2,
+			expectParams: &service.GetGameVersionsParams{
+				Limit: 1,
+			},
+			num: 2,
 			gameVersions: []*service.GameVersionInfo{
 				{
 					GameVersion: domain.NewGameVersion(
@@ -413,13 +414,15 @@ func TestGetGameVersion(t *testing.T) {
 			},
 		},
 		{
-			description:  "offsetが存在しても問題なし",
-			gameID:       gameID,
-			limit:        &one,
-			offset:       &one,
-			expectLimit:  1,
-			expectOffset: 1,
-			num:          2,
+			description: "offsetが存在しても問題なし",
+			gameID:      gameID,
+			limit:       &one,
+			offset:      &one,
+			expectParams: &service.GetGameVersionsParams{
+				Limit:  1,
+				Offset: 1,
+			},
+			num: 2,
 			gameVersions: []*service.GameVersionInfo{
 				{
 					GameVersion: domain.NewGameVersion(
@@ -461,10 +464,7 @@ func TestGetGameVersion(t *testing.T) {
 
 			mockGameVersionService.
 				EXPECT().
-				GetGameVersions(gomock.Any(), testCase.gameID, &service.GetGameVersionsParams{
-					Limit:  testCase.expectLimit,
-					Offset: testCase.expectOffset,
-				}).
+				GetGameVersions(gomock.Any(), testCase.gameID, testCase.expectParams).
 				Return(testCase.num, testCase.gameVersions, testCase.GetGameVersionErr)
 
 			err := gameVersionHandler.GetGameVersion(c, uuid.UUID(testCase.gameID), openapi.GetGameVersionParams{


### PR DESCRIPTION
`GET /games/:gameID/versions`でlimitもoffsetもない時`400 invalid limit`になっていたので、修正した。