### PR TITLE
users_test の実装

### DIFF
--- a/src/handler/v2/users.go
+++ b/src/handler/v2/users.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
+	openapi "github.com/traPtitech/trap-collection-server/src/handler/v2/openapi"
 	"github.com/traPtitech/trap-collection-server/src/service"
 )
 
@@ -43,7 +43,7 @@ func (u *User) GetMe(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, openapi.User{
-		Id:   uuid.UUID(userInfo.GetID()).String(),
+		Id:   uuid.UUID(userInfo.GetID()),
 		Name: string(userInfo.GetName()),
 	})
 }
@@ -71,7 +71,7 @@ func (u *User) GetUsers(c echo.Context) error {
 	users := make([]*openapi.User, 0, len(userInfos))
 	for _, userInfo := range userInfos {
 		users = append(users, &openapi.User{
-			Id:   uuid.UUID(userInfo.GetID()).String(),
+			Id:   uuid.UUID(userInfo.GetID()),
 			Name: string(userInfo.GetName()),
 		})
 	}

--- a/src/handler/v2/users_test.go
+++ b/src/handler/v2/users_test.go
@@ -367,8 +367,9 @@ func TestGetUsers(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, len(testCase.users), len(users))
-			for i, user := range users {
+			var resUser openapi.User
+			assert.Equal(t, len(testCase.users), len(resUser))
+			for i, user := range resUser {
 				assert.Equal(t, *testCase.users[i], *user)
 			}
 		})

--- a/src/handler/v2/users_test.go
+++ b/src/handler/v2/users_test.go
@@ -167,7 +167,14 @@ func TestGetMe(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, testCase.user, c.Get("user"))
+			var resUser *openapi.User
+			err = json.NewDecoder(rec.Body).Decode(&resUser)
+			if err != nil {
+				t.Fatalf("failed to decode response body: %v", err)
+			}
+
+			assert.Equal(t, testCase.user.Id, resUser.Id)
+			assert.Equal(t, testCase.user.Name, resUser.Name)
 		})
 	}
 }
@@ -354,7 +361,7 @@ func TestGetUsers(t *testing.T) {
 				return
 			}
 
-			var resUsers []openapi.User
+			var resUsers []*openapi.User
 			err = json.NewDecoder(rec.Body).Decode(&resUsers)
 			if err != nil {
 				t.Fatalf("failed to decode response body: %v", err)

--- a/src/handler/v2/users_test.go
+++ b/src/handler/v2/users_test.go
@@ -1,0 +1,376 @@
+package v2
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	mockConfig "github.com/traPtitech/trap-collection-server/src/config/mock"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/handler/common"
+	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
+	"github.com/traPtitech/trap-collection-server/src/service"
+	"github.com/traPtitech/trap-collection-server/src/service/mock"
+)
+
+func TestGetMe(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockUserService := mock.NewMockUser(ctrl)
+	mockConf := mockConfig.NewMockHandler(ctrl)
+	mockConf.
+		EXPECT().
+		SessionKey().
+		Return("key", nil)
+	mockConf.
+		EXPECT().
+		SessionSecret().
+		Return("secret", nil)
+	sess, err := common.NewSession(mockConf)
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+		return
+	}
+	session, err := NewSession(sess)
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+		return
+	}
+
+	userHandler := NewUser(session, mockUserService)
+
+	type test struct {
+		description      string
+		sessionExist     bool
+		authSessionExist bool
+		accessToken      string
+		expiresAt        time.Time
+		executeGetMe     bool
+		userInfo         *service.UserInfo
+		GetMeErr         error
+		user             *openapi.User
+		isErr            bool
+		err              error
+		statusCode       int
+	}
+
+	id1 := uuid.New()
+
+	testCases := []test{
+		{
+			description:      "特に問題ないのでエラーなし",
+			sessionExist:     true,
+			authSessionExist: true,
+			accessToken:      "accessToken",
+			expiresAt:        time.Now(),
+			executeGetMe:     true,
+			userInfo: service.NewUserInfo(
+				values.NewTrapMemberID(id1),
+				"mazrean",
+				values.TrapMemberStatusActive,
+			),
+			user: &openapi.User{
+				Id:   id1.String(),
+				Name: "mazrean",
+			},
+		},
+		{
+			// 実際にはmiddlewareで弾かれるが、念の為確認
+			description:  "sessionが存在しないのでauthSessionも存在せず500",
+			sessionExist: false,
+			isErr:        true,
+			statusCode:   http.StatusInternalServerError,
+		},
+		{
+			// 実際にはmiddlewareで弾かれるが、念の為確認
+			description:      "authSessionが存在しないので500",
+			sessionExist:     true,
+			authSessionExist: false,
+			isErr:            true,
+			statusCode:       http.StatusInternalServerError,
+		},
+		{
+			description:      "GetMeがエラーなので500",
+			sessionExist:     true,
+			authSessionExist: true,
+			accessToken:      "accessToken",
+			expiresAt:        time.Now(),
+			executeGetMe:     true,
+			GetMeErr:         errors.New("error"),
+			isErr:            true,
+			statusCode:       http.StatusInternalServerError,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/users/me", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if testCase.sessionExist {
+				sess, err := session.New(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if testCase.authSessionExist {
+					sess.Values[accessTokenSessionKey] = testCase.accessToken
+					sess.Values[expiresAtSessionKey] = testCase.expiresAt
+				}
+
+				err = sess.Save(req, rec)
+				if err != nil {
+					t.Fatalf("failed to save session: %v", err)
+				}
+
+				setCookieHeader(c)
+
+				sess, err = session.Get(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				c.Set(sessionContextKey, sess)
+			}
+
+			if testCase.executeGetMe {
+				mockUserService.
+					EXPECT().
+					GetMe(gomock.Any(), gomock.Any()).
+					Return(testCase.userInfo, testCase.GetMeErr)
+			}
+
+			user, err := userHandler.GetMe(c)
+
+			if testCase.isErr {
+				if testCase.statusCode != 0 {
+					var httpError *echo.HTTPError
+					if errors.As(err, &httpError) {
+						assert.Equal(t, testCase.statusCode, httpError.Code)
+					} else {
+						t.Errorf("error is not *echo.HTTPError")
+					}
+				} else if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, *testCase.user, *user)
+		})
+	}
+}
+
+func TestGetUsers(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockUserService := mock.NewMockUser(ctrl)
+	mockConf := mockConfig.NewMockHandler(ctrl)
+	mockConf.
+		EXPECT().
+		SessionKey().
+		Return("key", nil)
+	mockConf.
+		EXPECT().
+		SessionSecret().
+		Return("secret", nil)
+	sess, err := common.NewSession(mockConf)
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+		return
+	}
+	session, err := NewSession(sess)
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+		return
+	}
+
+	userHandler := NewUser(session, mockUserService)
+
+	type test struct {
+		description             string
+		sessionExist            bool
+		authSessionExist        bool
+		accessToken             string
+		expiresAt               time.Time
+		executeGetAllActiveUser bool
+		userInfos               []*service.UserInfo
+		GetAllActiveUserErr     error
+		users                   []*openapi.User
+		isErr                   bool
+		err                     error
+		statusCode              int
+	}
+
+	id1 := uuid.New()
+	id2 := uuid.New()
+
+	testCases := []test{
+		{
+			description:             "特に問題ないのでエラーなし",
+			sessionExist:            true,
+			authSessionExist:        true,
+			accessToken:             "accessToken",
+			expiresAt:               time.Now(),
+			executeGetAllActiveUser: true,
+			userInfos: []*service.UserInfo{
+				service.NewUserInfo(
+					values.NewTrapMemberID(id1),
+					"mazrean",
+					values.TrapMemberStatusActive,
+				),
+			},
+			users: []*openapi.User{
+				{
+					Id:   id1.String(),
+					Name: "mazrean",
+				},
+			},
+		},
+		{
+			description:             "userが複数でもエラーなし",
+			sessionExist:            true,
+			authSessionExist:        true,
+			accessToken:             "accessToken",
+			expiresAt:               time.Now(),
+			executeGetAllActiveUser: true,
+			userInfos: []*service.UserInfo{
+				service.NewUserInfo(
+					values.NewTrapMemberID(id1),
+					"mazrean",
+					values.TrapMemberStatusActive,
+				),
+				service.NewUserInfo(
+					values.NewTrapMemberID(id2),
+					"mazrean2",
+					values.TrapMemberStatusActive,
+				),
+			},
+			users: []*openapi.User{
+				{
+					Id:   id1.String(),
+					Name: "mazrean",
+				},
+				{
+					Id:   id2.String(),
+					Name: "mazrean2",
+				},
+			},
+		},
+		{
+			// 実際にはmiddlewareで弾かれるが、念の為確認
+			description:  "sessionが存在しないのでauthSessionも存在せず500",
+			sessionExist: false,
+			isErr:        true,
+			statusCode:   http.StatusInternalServerError,
+		},
+		{
+			// 実際にはmiddlewareで弾かれるが、念の為確認
+			description:      "authSessionが存在しないので500",
+			sessionExist:     true,
+			authSessionExist: false,
+			isErr:            true,
+			statusCode:       http.StatusInternalServerError,
+		},
+		{
+			description:             "GetAllActiveUserがエラーなので500",
+			sessionExist:            true,
+			authSessionExist:        true,
+			accessToken:             "accessToken",
+			expiresAt:               time.Now(),
+			executeGetAllActiveUser: true,
+			GetAllActiveUserErr:     errors.New("error"),
+			isErr:                   true,
+			statusCode:              http.StatusInternalServerError,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/users/me", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if testCase.sessionExist {
+				sess, err := session.New(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if testCase.authSessionExist {
+					sess.Values[accessTokenSessionKey] = testCase.accessToken
+					sess.Values[expiresAtSessionKey] = testCase.expiresAt
+				}
+
+				err = sess.Save(req, rec)
+				if err != nil {
+					t.Fatalf("failed to save session: %v", err)
+				}
+
+				setCookieHeader(c)
+
+				sess, err = session.Get(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				c.Set(sessionContextKey, sess)
+			}
+
+			if testCase.executeGetAllActiveUser {
+				mockUserService.
+					EXPECT().
+					GetAllActiveUser(gomock.Any(), gomock.Any()).
+					Return(testCase.userInfos, testCase.GetAllActiveUserErr)
+			}
+
+			users, err := userHandler.GetUsers(c)
+
+			if testCase.isErr {
+				if testCase.statusCode != 0 {
+					var httpError *echo.HTTPError
+					if errors.As(err, &httpError) {
+						assert.Equal(t, testCase.statusCode, httpError.Code)
+					} else {
+						t.Errorf("error is not *echo.HTTPError")
+					}
+				} else if testCase.err == nil {
+					assert.Error(t, err)
+				} else if !errors.Is(err, testCase.err) {
+					t.Errorf("error must be %v, but actual is %v", testCase.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, len(testCase.users), len(users))
+			for i, user := range users {
+				assert.Equal(t, *testCase.users[i], *user)
+			}
+		})
+	}
+}

--- a/src/handler/v2/users_test.go
+++ b/src/handler/v2/users_test.go
@@ -141,7 +141,7 @@ func TestGetMe(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				c.Set(sessionContextKey, sess)
+				setCookieHeader(c)
 			}
 
 			if testCase.executeGetMe {
@@ -151,7 +151,7 @@ func TestGetMe(t *testing.T) {
 					Return(testCase.userInfo, testCase.GetMeErr)
 			}
 
-			user, err := userHandler.GetMe(c)
+			user := userHandler.GetMe(c)
 
 			if testCase.isErr {
 				if testCase.statusCode != 0 {
@@ -173,7 +173,7 @@ func TestGetMe(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, *testCase.user, *user)
+			assert.Equal(t, *testCase.user, user)
 		})
 	}
 }
@@ -335,7 +335,7 @@ func TestGetUsers(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				c.Set(sessionContextKey, sess)
+				setCookieHeader(c)
 			}
 
 			if testCase.executeGetAllActiveUser {
@@ -345,7 +345,7 @@ func TestGetUsers(t *testing.T) {
 					Return(testCase.userInfos, testCase.GetAllActiveUserErr)
 			}
 
-			users, err := userHandler.GetUsers(c)
+			users := userHandler.GetUsers(c)
 
 			if testCase.isErr {
 				if testCase.statusCode != 0 {


### PR DESCRIPTION
370行目~373行目の
![image](https://user-images.githubusercontent.com/17543997/197146265-069cabbf-0a35-4d0f-8e07-5c9b6209f9bc.png)
ここの直し方が分かりません。
ver1ではusersは
![image](https://user-images.githubusercontent.com/17543997/197146929-86dda0de-85b1-4ea0-b0e5-6861e95680df.png)
このように定義されているので、[]*openapi.User型が入っているのですが、v2ではerr型であるため、比べるものが変わってしまっています。
他のファイルを参考にしようとすると、v2/game_image_testの最後らへんが近そうなことをしているのですが、
![image](https://user-images.githubusercontent.com/17543997/197148733-404ba3ed-7f96-496e-862a-2ce4d0e49825.png)
上のように書いてあったので、参考にしながら書いてみたのですが全然違うと思います。
どうすれば370-373行目を実装できるでしょうか？よろしくお願いします。