### PR TITLE
エディションの認可周りのchecker実装

### DIFF
--- a/src/repository/edition.go
+++ b/src/repository/edition.go
@@ -35,4 +35,16 @@ type Edition interface {
 	// エディションに含まれるゲームバージョンの取得。
 	// 並び順はCreatedAtの降順。
 	GetEditionGameVersions(ctx context.Context, editionID values.LauncherVersionID, lockType LockType) ([]*GameVersionInfoWithGameID, error)
+	// GetEditionGameVersionByGameID
+	// ゲームでのエディションに含まれるゲームバージョンの取得。
+	GetEditionGameVersionByGameID(ctx context.Context, editionID values.LauncherVersionID, gameID values.GameID, lockType LockType) (*domain.GameVersion, error)
+	// GetEditionGameVersionByImageID
+	// 画像でのエディションに含まれるゲームバージョンの取得。
+	GetEditionGameVersionByImageID(ctx context.Context, editionID values.LauncherVersionID, imageID values.GameImageID, lockType LockType) (*domain.GameVersion, error)
+	// GetEditionGameVersionByVideoID
+	// 動画でのエディションに含まれるゲームバージョンの取得。
+	GetEditionGameVersionByVideoID(ctx context.Context, editionID values.LauncherVersionID, videoID values.GameVideoID, lockType LockType) (*domain.GameVersion, error)
+	// GetEditionGameVersionByFileID
+	// ファイルでのエディションに含まれるゲームバージョンの取得。
+	GetEditionGameVersionByFileID(ctx context.Context, editionID values.LauncherVersionID, fileID values.GameFileID, lockType LockType) (*domain.GameVersion, error)
 }

--- a/src/repository/gorm2/access_token.go
+++ b/src/repository/gorm2/access_token.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log"
 	"net/url"
 	"time"
 
@@ -107,7 +106,6 @@ func (accessToken *AccessToken) GetAccessTokenInfo(ctx context.Context, token va
 		return nil, fmt.Errorf("failed to get edition: %w", err)
 	}
 
-	log.Println(scanStruct)
 	dbEdition := scanStruct.Edition
 	dbProductKey := scanStruct.ProductKey
 	dbAccessToken := scanStruct.AccessToken

--- a/src/repository/gorm2/edition.go
+++ b/src/repository/gorm2/edition.go
@@ -16,6 +16,8 @@ import (
 	"gorm.io/gorm"
 )
 
+var _ repository.Edition = (*Edition)(nil)
+
 type Edition struct {
 	db *DB
 }
@@ -300,4 +302,126 @@ func (e *Edition) GetEditionGameVersions(ctx context.Context, editionID values.L
 	}
 
 	return result, nil
+}
+
+func (edition *Edition) GetEditionGameVersionByGameID(ctx context.Context, editionID values.LauncherVersionID, gameID values.GameID, lockType repository.LockType) (*domain.GameVersion, error) {
+	db, err := edition.db.getDB(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get db: %w", err)
+	}
+
+	db, err = edition.db.setLock(db, lockType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set lock: %w", err)
+	}
+
+	var gameVersion migrate.GameVersionTable2
+	err = db.
+		Joins("INNER JOIN edition_game_version_relations ON edition_game_version_relations.game_version_id = v2_game_versions.id").
+		Where("v2_game_versions.game_id = ?", uuid.UUID(gameID)).
+		Take(&gameVersion).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, repository.ErrRecordNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get edition game version: %w", err)
+	}
+
+	return domain.NewGameVersion(
+		values.NewGameVersionIDFromUUID(gameVersion.ID),
+		values.NewGameVersionName(gameVersion.Name),
+		values.NewGameVersionDescription(gameVersion.Description),
+		gameVersion.CreatedAt,
+	), nil
+}
+
+func (edition *Edition) GetEditionGameVersionByImageID(ctx context.Context, editionID values.LauncherVersionID, imageID values.GameImageID, lockType repository.LockType) (*domain.GameVersion, error) {
+	db, err := edition.db.getDB(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get db: %w", err)
+	}
+
+	db, err = edition.db.setLock(db, lockType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set lock: %w", err)
+	}
+
+	var gameVersion migrate.GameVersionTable2
+	err = db.
+		Where("game_image_id = ?", uuid.UUID(imageID)).
+		Take(&gameVersion).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, repository.ErrRecordNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get edition game version: %w", err)
+	}
+
+	return domain.NewGameVersion(
+		values.NewGameVersionIDFromUUID(gameVersion.ID),
+		values.NewGameVersionName(gameVersion.Name),
+		values.NewGameVersionDescription(gameVersion.Description),
+		gameVersion.CreatedAt,
+	), nil
+}
+
+func (edition *Edition) GetEditionGameVersionByVideoID(ctx context.Context, editionID values.LauncherVersionID, videoID values.GameVideoID, lockType repository.LockType) (*domain.GameVersion, error) {
+	db, err := edition.db.getDB(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get db: %w", err)
+	}
+
+	db, err = edition.db.setLock(db, lockType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set lock: %w", err)
+	}
+
+	var gameVersion migrate.GameVersionTable2
+	err = db.
+		Where("game_video_id = ?", uuid.UUID(videoID)).
+		Take(&gameVersion).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, repository.ErrRecordNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get edition game version: %w", err)
+	}
+
+	return domain.NewGameVersion(
+		values.NewGameVersionIDFromUUID(gameVersion.ID),
+		values.NewGameVersionName(gameVersion.Name),
+		values.NewGameVersionDescription(gameVersion.Description),
+		gameVersion.CreatedAt,
+	), nil
+}
+
+func (edition *Edition) GetEditionGameVersionByFileID(ctx context.Context, editionID values.LauncherVersionID, fileID values.GameFileID, lockType repository.LockType) (*domain.GameVersion, error) {
+	db, err := edition.db.getDB(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get db: %w", err)
+	}
+
+	db, err = edition.db.setLock(db, lockType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set lock: %w", err)
+	}
+
+	var gameVersion migrate.GameVersionTable2
+	err = db.
+		Joins("INNER JOIN game_version_game_file_relations ON game_version_game_file_relations.game_version_id = v2_game_versions.id").
+		Where("game_version_game_file_relations.game_file_id = ?", uuid.UUID(fileID)).
+		Take(&gameVersion).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, repository.ErrRecordNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get edition game version: %w", err)
+	}
+
+	return domain.NewGameVersion(
+		values.NewGameVersionIDFromUUID(gameVersion.ID),
+		values.NewGameVersionName(gameVersion.Name),
+		values.NewGameVersionDescription(gameVersion.Description),
+		gameVersion.CreatedAt,
+	), nil
 }

--- a/src/repository/gorm2/edition.go
+++ b/src/repository/gorm2/edition.go
@@ -304,13 +304,13 @@ func (e *Edition) GetEditionGameVersions(ctx context.Context, editionID values.L
 	return result, nil
 }
 
-func (edition *Edition) GetEditionGameVersionByGameID(ctx context.Context, editionID values.LauncherVersionID, gameID values.GameID, lockType repository.LockType) (*domain.GameVersion, error) {
-	db, err := edition.db.getDB(ctx)
+func (e *Edition) GetEditionGameVersionByGameID(ctx context.Context, editionID values.LauncherVersionID, gameID values.GameID, lockType repository.LockType) (*domain.GameVersion, error) {
+	db, err := e.db.getDB(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get db: %w", err)
 	}
 
-	db, err = edition.db.setLock(db, lockType)
+	db, err = e.db.setLock(db, lockType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set lock: %w", err)
 	}
@@ -335,13 +335,13 @@ func (edition *Edition) GetEditionGameVersionByGameID(ctx context.Context, editi
 	), nil
 }
 
-func (edition *Edition) GetEditionGameVersionByImageID(ctx context.Context, editionID values.LauncherVersionID, imageID values.GameImageID, lockType repository.LockType) (*domain.GameVersion, error) {
-	db, err := edition.db.getDB(ctx)
+func (e *Edition) GetEditionGameVersionByImageID(ctx context.Context, editionID values.LauncherVersionID, imageID values.GameImageID, lockType repository.LockType) (*domain.GameVersion, error) {
+	db, err := e.db.getDB(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get db: %w", err)
 	}
 
-	db, err = edition.db.setLock(db, lockType)
+	db, err = e.db.setLock(db, lockType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set lock: %w", err)
 	}
@@ -365,13 +365,13 @@ func (edition *Edition) GetEditionGameVersionByImageID(ctx context.Context, edit
 	), nil
 }
 
-func (edition *Edition) GetEditionGameVersionByVideoID(ctx context.Context, editionID values.LauncherVersionID, videoID values.GameVideoID, lockType repository.LockType) (*domain.GameVersion, error) {
-	db, err := edition.db.getDB(ctx)
+func (e *Edition) GetEditionGameVersionByVideoID(ctx context.Context, editionID values.LauncherVersionID, videoID values.GameVideoID, lockType repository.LockType) (*domain.GameVersion, error) {
+	db, err := e.db.getDB(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get db: %w", err)
 	}
 
-	db, err = edition.db.setLock(db, lockType)
+	db, err = e.db.setLock(db, lockType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set lock: %w", err)
 	}
@@ -395,13 +395,13 @@ func (edition *Edition) GetEditionGameVersionByVideoID(ctx context.Context, edit
 	), nil
 }
 
-func (edition *Edition) GetEditionGameVersionByFileID(ctx context.Context, editionID values.LauncherVersionID, fileID values.GameFileID, lockType repository.LockType) (*domain.GameVersion, error) {
-	db, err := edition.db.getDB(ctx)
+func (e *Edition) GetEditionGameVersionByFileID(ctx context.Context, editionID values.LauncherVersionID, fileID values.GameFileID, lockType repository.LockType) (*domain.GameVersion, error) {
+	db, err := e.db.getDB(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get db: %w", err)
 	}
 
-	db, err = edition.db.setLock(db, lockType)
+	db, err = e.db.setLock(db, lockType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set lock: %w", err)
 	}

--- a/src/service/edition_auth.go
+++ b/src/service/edition_auth.go
@@ -39,6 +39,34 @@ type EditionAuth interface {
 	// アクセストークンが存在しない、もしくは無効な場合、ErrInvalidAccessTokenを返します。
 	// アクセストークンが期限切れの場合、ErrExpiredAccessTokenを返します。
 	EditionAuth(ctx context.Context, accessToken values.LauncherSessionAccessToken) (*domain.LauncherUser, *domain.LauncherVersion, error)
+	// EditionGameAuth
+	// エディション情報へのアクセストークンを検証し、
+	// ゲーム情報にアクセスできるかどうかチェックします。
+	// アクセストークンが存在しない、もしくは無効な場合、ErrInvalidAccessTokenを返します。
+	// アクセストークンが期限切れの場合、ErrExpiredAccessTokenを返します。
+	// ゲーム情報にアクセスできない、もしくはゲームが存在しない場合、ErrForbiddenを返します。
+	EditionGameAuth(ctx context.Context, accessToken values.LauncherSessionAccessToken, gameID values.GameID) (*domain.LauncherUser, *domain.LauncherVersion, error)
+	// EditionImageAuth
+	// エディション情報へのアクセストークンを検証し、
+	// イメージ情報にアクセスできるかどうかチェックします。
+	// アクセストークンが存在しない、もしくは無効な場合、ErrInvalidAccessTokenを返します。
+	// アクセストークンが期限切れの場合、ErrExpiredAccessTokenを返します。
+	// イメージ情報にアクセスできない、もしくはイメージが存在しない場合、ErrForbiddenを返します。
+	EditionImageAuth(ctx context.Context, accessToken values.LauncherSessionAccessToken, imageID values.GameImageID) (*domain.LauncherUser, *domain.LauncherVersion, error)
+	// EditionVideoAuth
+	// エディション情報へのアクセストークンを検証し、
+	// 動画情報にアクセスできるかどうかチェックします。
+	// アクセストークンが存在しない、もしくは無効な場合、ErrInvalidAccessTokenを返します。
+	// アクセストークンが期限切れの場合、ErrExpiredAccessTokenを返します。
+	// 動画情報にアクセスできない、もしくは動画が存在しない場合、ErrForbiddenを返します。
+	EditionVideoAuth(ctx context.Context, accessToken values.LauncherSessionAccessToken, videoID values.GameVideoID) (*domain.LauncherUser, *domain.LauncherVersion, error)
+	// EditionFileAuth
+	// エディション情報へのアクセストークンを検証し、
+	// ファイル情報にアクセスできるかどうかチェックします。
+	// アクセストークンが存在しない、もしくは無効な場合、ErrInvalidAccessTokenを返します。
+	// アクセストークンが期限切れの場合、ErrExpiredAccessTokenを返します。
+	// ファイル情報にアクセスできない、もしくはファイルが存在しない場合、ErrForbiddenを返します。
+	EditionFileAuth(ctx context.Context, accessToken values.LauncherSessionAccessToken, fileID values.GameFileID) (*domain.LauncherUser, *domain.LauncherVersion, error)
 }
 
 type GetProductKeysParams struct {

--- a/src/service/v2/edition_auth.go
+++ b/src/service/v2/edition_auth.go
@@ -203,3 +203,115 @@ func (editionAuth *EditionAuth) EditionAuth(ctx context.Context, token values.La
 
 	return accessTokenInfo.ProductKey, accessTokenInfo.Edition, nil
 }
+
+func (editionAuth *EditionAuth) EditionGameAuth(ctx context.Context, token values.LauncherSessionAccessToken, gameID values.GameID) (*domain.LauncherUser, *domain.LauncherVersion, error) {
+	accessTokenInfo, err := editionAuth.accessTokenRepository.GetAccessTokenInfo(ctx, token, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, nil, service.ErrInvalidAccessToken
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get launcher version and user and session: %w", err)
+	}
+
+	if accessTokenInfo.ProductKey.GetStatus() == values.LauncherUserStatusInactive {
+		return nil, nil, service.ErrInvalidAccessToken
+	}
+
+	if accessTokenInfo.AccessToken.IsExpired() {
+		return nil, nil, service.ErrExpiredAccessToken
+	}
+
+	_, err = editionAuth.editionRepository.GetEditionGameVersionByGameID(ctx, accessTokenInfo.Edition.GetID(), gameID, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, nil, service.ErrForbidden
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get launcher version and user and session: %w", err)
+	}
+
+	return accessTokenInfo.ProductKey, accessTokenInfo.Edition, nil
+}
+
+func (editionAuth *EditionAuth) EditionImageAuth(ctx context.Context, token values.LauncherSessionAccessToken, imageID values.GameImageID) (*domain.LauncherUser, *domain.LauncherVersion, error) {
+	accessTokenInfo, err := editionAuth.accessTokenRepository.GetAccessTokenInfo(ctx, token, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, nil, service.ErrInvalidAccessToken
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get launcher version and user and session: %w", err)
+	}
+
+	if accessTokenInfo.ProductKey.GetStatus() == values.LauncherUserStatusInactive {
+		return nil, nil, service.ErrInvalidAccessToken
+	}
+
+	if accessTokenInfo.AccessToken.IsExpired() {
+		return nil, nil, service.ErrExpiredAccessToken
+	}
+
+	_, err = editionAuth.editionRepository.GetEditionGameVersionByImageID(ctx, accessTokenInfo.Edition.GetID(), imageID, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, nil, service.ErrForbidden
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get launcher version and user and session: %w", err)
+	}
+
+	return accessTokenInfo.ProductKey, accessTokenInfo.Edition, nil
+}
+
+func (editionAuth *EditionAuth) EditionVideoAuth(ctx context.Context, token values.LauncherSessionAccessToken, videoID values.GameVideoID) (*domain.LauncherUser, *domain.LauncherVersion, error) {
+	accessTokenInfo, err := editionAuth.accessTokenRepository.GetAccessTokenInfo(ctx, token, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, nil, service.ErrInvalidAccessToken
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get launcher version and user and session: %w", err)
+	}
+
+	if accessTokenInfo.ProductKey.GetStatus() == values.LauncherUserStatusInactive {
+		return nil, nil, service.ErrInvalidAccessToken
+	}
+
+	if accessTokenInfo.AccessToken.IsExpired() {
+		return nil, nil, service.ErrExpiredAccessToken
+	}
+
+	_, err = editionAuth.editionRepository.GetEditionGameVersionByVideoID(ctx, accessTokenInfo.Edition.GetID(), videoID, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, nil, service.ErrForbidden
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get launcher version and user and session: %w", err)
+	}
+
+	return accessTokenInfo.ProductKey, accessTokenInfo.Edition, nil
+}
+
+func (editionAuth *EditionAuth) EditionFileAuth(ctx context.Context, accessToken values.LauncherSessionAccessToken, fileID values.GameFileID) (*domain.LauncherUser, *domain.LauncherVersion, error) {
+	accessTokenInfo, err := editionAuth.accessTokenRepository.GetAccessTokenInfo(ctx, accessToken, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, nil, service.ErrInvalidAccessToken
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get launcher version and user and session: %w", err)
+	}
+
+	if accessTokenInfo.ProductKey.GetStatus() == values.LauncherUserStatusInactive {
+		return nil, nil, service.ErrInvalidAccessToken
+	}
+
+	if accessTokenInfo.AccessToken.IsExpired() {
+		return nil, nil, service.ErrExpiredAccessToken
+	}
+
+	_, err = editionAuth.editionRepository.GetEditionGameVersionByFileID(ctx, accessTokenInfo.Edition.GetID(), fileID, repository.LockTypeNone)
+	if errors.Is(err, repository.ErrRecordNotFound) {
+		return nil, nil, service.ErrForbidden
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get launcher version and user and session: %w", err)
+	}
+
+	return accessTokenInfo.ProductKey, accessTokenInfo.Edition, nil
+}


### PR DESCRIPTION
実装した。
テストなし。
`GET /games/{gameID}`に関しては、ランチャーから上手く叩けなくなっているのをどうにかする必要がある。