### PR TITLE
ゲームの権限チェック周りの実装

### DIFF
--- a/src/handler/v2/checker.go
+++ b/src/handler/v2/checker.go
@@ -150,8 +150,10 @@ func (checker *Checker) GameOwnerAuthChecker(ctx context.Context, ai *openapi3fi
 	}
 
 	authSession, err := checker.session.getAuthSession(session)
+	if errors.Is(err, ErrNoValue) {
+		return echo.NewHTTPError(http.StatusUnauthorized, "no access token")
+	}
 	if err != nil {
-		// TrapMemberAuthMiddlewareでErrNoValueなどは弾かれているはずなので、ここでエラーは起きないはず
 		log.Printf("error: failed to get auth session: %v\n", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -205,8 +207,10 @@ func (checker *Checker) GameMaintainerAuthChecker(ctx context.Context, ai *opena
 	}
 
 	authSession, err := checker.session.getAuthSession(session)
+	if errors.Is(err, ErrNoValue) {
+		return echo.NewHTTPError(http.StatusUnauthorized, "no access token")
+	}
 	if err != nil {
-		// TrapMemberAuthMiddlewareでErrNoValueなどは弾かれているはずなので、ここでエラーは起きないはず
 		log.Printf("error: failed to get auth session: %v\n", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/src/handler/v2/checker.go
+++ b/src/handler/v2/checker.go
@@ -52,8 +52,8 @@ func (checker *Checker) check(ctx context.Context, input *openapi3filter.Authent
 	checkerMap := map[string]openapi3filter.AuthenticationFunc{
 		"TrapMemberAuth":       checker.TrapMemberAuthChecker,
 		"AdminAuth":            checker.noAuthChecker, // TODO: AdminAuthChecker
-		"GameOwnerAuth":        checker.noAuthChecker, // TODO: GameOwnerAuthChecker
-		"GameMaintainerAuth":   checker.noAuthChecker, // TODO: GameMaintainerAuthChecker
+		"GameOwnerAuth":        checker.GameOwnerAuthChecker,
+		"GameMaintainerAuth":   checker.GameMaintainerAuthChecker,
 		"EditionAuth":          checker.EditionAuthChecker,
 		"EditionGameAuth":      checker.EditionGameAuthChecker,
 		"EditionGameFileAuth":  checker.EditionGameFileAuthChecker,
@@ -169,7 +169,7 @@ func (checker *Checker) GameOwnerAuthChecker(ctx context.Context, ai *openapi3fi
 	strGameID := c.Param("gameID")
 	uuidGameID, err := uuid.Parse(strGameID)
 	if err != nil {
-		echo.NewHTTPError(http.StatusBadRequest, "invalid gameID")
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid gameID")
 	}
 	gameID := values.NewGameIDFromUUID(uuidGameID)
 
@@ -224,7 +224,7 @@ func (checker *Checker) GameMaintainerAuthChecker(ctx context.Context, ai *opena
 	strGameID := c.Param("gameID")
 	uuidGameID, err := uuid.Parse(strGameID)
 	if err != nil {
-		echo.NewHTTPError(http.StatusBadRequest, "invalid gameID")
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid gameID")
 	}
 	gameID := values.NewGameIDFromUUID(uuidGameID)
 

--- a/src/handler/v2/checker_test.go
+++ b/src/handler/v2/checker_test.go
@@ -32,6 +32,8 @@ func TestTrapMemberAuthMiddleware(t *testing.T) {
 	mockOIDCService := mock.NewMockOIDCV2(ctrl)
 	mockEditionService := mock.NewMockEdition(ctrl)
 	mockEditionAuthService := mock.NewMockEditionAuth(ctrl)
+	mockGameRoleService := mock.NewMockGameRoleV2(ctrl)
+	mockAdministratorAuthService := mock.NewMockAdministratorAuth(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -58,6 +60,8 @@ func TestTrapMemberAuthMiddleware(t *testing.T) {
 		mockOIDCService,
 		mockEditionService,
 		mockEditionAuthService,
+		mockGameRoleService,
+		mockAdministratorAuthService,
 	)
 
 	type test struct {
@@ -159,6 +163,8 @@ func TestCheckTrapMemberAuth(t *testing.T) {
 	mockOIDCService := mock.NewMockOIDCV2(ctrl)
 	mockEditionService := mock.NewMockEdition(ctrl)
 	mockEditionAuthService := mock.NewMockEditionAuth(ctrl)
+	mockGameRoleService := mock.NewMockGameRoleV2(ctrl)
+	mockAdministratorAuthService := mock.NewMockAdministratorAuth(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -185,6 +191,8 @@ func TestCheckTrapMemberAuth(t *testing.T) {
 		mockOIDCService,
 		mockEditionService,
 		mockEditionAuthService,
+		mockGameRoleService,
+		mockAdministratorAuthService,
 	)
 
 	type test struct {

--- a/src/wire/wire_gen.go
+++ b/src/wire/wire_gen.go
@@ -194,7 +194,8 @@ func InjectApp() (*App, error) {
 	productKey := gorm2.NewProductKey(db)
 	accessToken := gorm2.NewAccessToken(db)
 	editionAuth := v2_2.NewEditionAuth(db, edition, productKey, accessToken)
-	checker := v2.NewChecker(context, v2Session, v2OIDC, v2Edition, editionAuth)
+	v2GameRole := v2_2.NewGameRole(db, gameV2, gameManagementRole, v2User)
+	checker := v2.NewChecker(context, v2Session, v2OIDC, v2Edition, editionAuth, v2GameRole, administratorAuth)
 	v2OAuth2, err := v2.NewOAuth2(v1Handler, v2Session, v2OIDC)
 	if err != nil {
 		return nil, err
@@ -203,7 +204,6 @@ func InjectApp() (*App, error) {
 	admin := v2.NewAdmin()
 	v2Game := v2_2.NewGame(db, gameV2, gameManagementRole, v2User)
 	game3 := v2.NewGame(v2Session, v2Game)
-	v2GameRole := v2_2.NewGameRole(db, gameV2, gameManagementRole, v2User)
 	gameRole2 := v2.NewGameRole(v2GameRole, v2Game, v2Session)
 	gameImageV2 := gorm2.NewGameImageV2(db)
 	gameVideoV2 := gorm2.NewGameVideoV2(db)


### PR DESCRIPTION
した。テストは存在しない。
`AdministratorAuth`はv1のものを使っている。
ローカルでの動作は、
- owner、maintainerではないゲームをいじれない
- ownerであるとき、いじれるし消せる
- maintainerのときいじれるけど消せない

ことを確認した。
