### PR TITLE
画像、動画、ファイルを管理者以外もpostできていた問題修正

### DIFF
--- a/docs/openapi/v2.yaml
+++ b/docs/openapi/v2.yaml
@@ -764,7 +764,7 @@ paths:
       tags:
         - gameFile
       security:
-        - TrapMemberAuth: []
+        - GameMaintainerAuth: []
       operationId: postGameFile
       requestBody:
         content:
@@ -946,7 +946,7 @@ paths:
       tags:
         - gameImage
       security:
-        - TrapMemberAuth: []
+        - GameMaintainerAuth: []
       operationId: postGameImage
       requestBody:
         content:
@@ -1128,7 +1128,7 @@ paths:
       tags:
         - gameVideo
       security:
-        - TrapMemberAuth: []
+        - GameMaintainerAuth: []
       operationId: postGameVideo
       requestBody:
         content:


### PR DESCRIPTION
権限の設定ミスで、traPのメンバーの誰でもpostできるようになっていたので、修正した。