### PR TITLE
NewGameFileのtypeをstringに

### DIFF
--- a/docs/openapi/v2.yaml
+++ b/docs/openapi/v2.yaml
@@ -2425,7 +2425,10 @@ components:
       type: object
       properties:
         type:
-          $ref: '#/components/schemas/GameFileType'
+          # OpenAPI Generatorのバグで、enumだとクライアントの生成がうまくいかないので、
+          # 一旦stringにしている
+          type: string
+          example: 'jar'
         entryPoint:
           $ref: '#/components/schemas/GameFileEntryPoint'
         content:


### PR DESCRIPTION
OpenAPI Generatorのバグでクライアントの生成がうまくいかないので、暫定的にNewGameFileのtypeフィールドをstringにした。