### PR TITLE
v1の書き込み系api停止用環境変数作成

### DIFF
--- a/src/config/app.go
+++ b/src/config/app.go
@@ -12,4 +12,5 @@ const (
 type App interface {
 	Status() (AppStatus, error)
 	FeatureV2() bool
+	FeatureV1Write() bool
 }

--- a/src/config/v1/app.go
+++ b/src/config/v1/app.go
@@ -45,3 +45,18 @@ func (*App) FeatureV2() bool {
 
 	return v2
 }
+
+func (*App) FeatureV1Write() bool {
+	env, ok := os.LookupEnv(envKeyFeatureV1Write)
+	if !ok {
+		return true
+	}
+
+	v2, err := strconv.ParseBool(env)
+	if err != nil {
+		log.Printf("failed to parse %s: %v\n", envKeyFeatureV2, err)
+		return true
+	}
+
+	return v2
+}

--- a/src/config/v1/env.go
+++ b/src/config/v1/env.go
@@ -3,8 +3,9 @@ package v1
 type envKey = string
 
 const (
-	envKeyCollectionEnv envKey = "COLLECTION_ENV"
-	envKeyFeatureV2     envKey = "FEATURE_V2"
+	envKeyCollectionEnv  envKey = "COLLECTION_ENV"
+	envKeyFeatureV2      envKey = "FEATURE_V2"
+	envKeyFeatureV1Write envKey = "FEATURE_V1_WRITE"
 
 	envKeyStorage envKey = "STORAGE"
 

--- a/src/handler/v1/game_file.go
+++ b/src/handler/v1/game_file.go
@@ -11,22 +11,29 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/trap-collection-server/src/config"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
 	"github.com/traPtitech/trap-collection-server/src/service"
 )
 
 type GameFile struct {
+	featureWrite    bool
 	gameFileService service.GameFile
 }
 
-func NewGameFile(gameFileService service.GameFile) *GameFile {
+func NewGameFile(appConf config.App, gameFileService service.GameFile) *GameFile {
 	return &GameFile{
+		featureWrite:    appConf.FeatureV1Write(),
 		gameFileService: gameFileService,
 	}
 }
 
 func (gf *GameFile) PostFile(c echo.Context, strGameID string, strEntryPoint string, strFileType string, file multipart.File) (*openapi.GameFile, error) {
+	if !gf.featureWrite {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "v1 write is disabled")
+	}
+
 	ctx := c.Request().Context()
 
 	uuidGameID, err := uuid.Parse(strGameID)

--- a/src/handler/v1/game_file_test.go
+++ b/src/handler/v1/game_file_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	mockConfig "github.com/traPtitech/trap-collection-server/src/config/mock"
 	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
@@ -27,9 +28,10 @@ func TestPostFile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockGameFileService := mock.NewMockGameFile(ctrl)
 
-	gameFileHandler := NewGameFile(mockGameFileService)
+	gameFileHandler := NewGameFile(mockAppConfig, mockGameFileService)
 
 	type test struct {
 		description         string
@@ -256,9 +258,10 @@ func TestGetGameFile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockGameFileService := mock.NewMockGameFile(ctrl)
 
-	gameFileHandler := NewGameFile(mockGameFileService)
+	gameFileHandler := NewGameFile(mockAppConfig, mockGameFileService)
 
 	type test struct {
 		description        string

--- a/src/handler/v1/game_file_test.go
+++ b/src/handler/v1/game_file_test.go
@@ -29,6 +29,10 @@ func TestPostFile(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameFileService := mock.NewMockGameFile(ctrl)
 
 	gameFileHandler := NewGameFile(mockAppConfig, mockGameFileService)
@@ -259,6 +263,10 @@ func TestGetGameFile(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameFileService := mock.NewMockGameFile(ctrl)
 
 	gameFileHandler := NewGameFile(mockAppConfig, mockGameFileService)

--- a/src/handler/v1/game_image.go
+++ b/src/handler/v1/game_image.go
@@ -10,21 +10,28 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/trap-collection-server/src/config"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/service"
 )
 
 type GameImage struct {
+	featureWrite     bool
 	gameImageService service.GameImage
 }
 
-func NewGameImage(gameImageService service.GameImage) *GameImage {
+func NewGameImage(appConf config.App, gameImageService service.GameImage) *GameImage {
 	return &GameImage{
+		featureWrite:     appConf.FeatureV1Write(),
 		gameImageService: gameImageService,
 	}
 }
 
 func (gi *GameImage) PostImage(c echo.Context, strGameID string, image multipart.File) error {
+	if !gi.featureWrite {
+		return echo.NewHTTPError(http.StatusForbidden, "v1 write is disabled")
+	}
+
 	ctx := c.Request().Context()
 
 	uuidGameID, err := uuid.Parse(strGameID)

--- a/src/handler/v1/game_image_test.go
+++ b/src/handler/v1/game_image_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	mockConf "github.com/traPtitech/trap-collection-server/src/config/mock"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/service"
 	"github.com/traPtitech/trap-collection-server/src/service/mock"
@@ -24,9 +25,10 @@ func TestPostImage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConf.NewMockApp(ctrl)
 	mockGameImageService := mock.NewMockGameImage(ctrl)
 
-	gameImageHandler := NewGameImage(mockGameImageService)
+	gameImageHandler := NewGameImage(mockAppConfig, mockGameImageService)
 
 	type test struct {
 		description          string
@@ -136,9 +138,10 @@ func TestGetImage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConf.NewMockApp(ctrl)
 	mockGameImageService := mock.NewMockGameImage(ctrl)
 
-	gameImageHandler := NewGameImage(mockGameImageService)
+	gameImageHandler := NewGameImage(mockAppConfig, mockGameImageService)
 
 	type test struct {
 		description         string

--- a/src/handler/v1/game_image_test.go
+++ b/src/handler/v1/game_image_test.go
@@ -26,6 +26,10 @@ func TestPostImage(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConf.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameImageService := mock.NewMockGameImage(ctrl)
 
 	gameImageHandler := NewGameImage(mockAppConfig, mockGameImageService)
@@ -139,6 +143,10 @@ func TestGetImage(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConf.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameImageService := mock.NewMockGameImage(ctrl)
 
 	gameImageHandler := NewGameImage(mockAppConfig, mockGameImageService)

--- a/src/handler/v1/game_role.go
+++ b/src/handler/v1/game_role.go
@@ -7,24 +7,31 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/trap-collection-server/src/config"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
 	"github.com/traPtitech/trap-collection-server/src/service"
 )
 
 type GameRole struct {
+	featureWrite    bool
 	session         *Session
 	gameAuthService service.GameAuth
 }
 
-func NewGameRole(session *Session, gameAuthService service.GameAuth) *GameRole {
+func NewGameRole(appConf config.App, session *Session, gameAuthService service.GameAuth) *GameRole {
 	return &GameRole{
+		featureWrite:    appConf.FeatureV1Write(),
 		session:         session,
 		gameAuthService: gameAuthService,
 	}
 }
 
 func (gr *GameRole) PostMaintainer(c echo.Context, strGameID string, maintainers *openapi.Maintainers) error {
+	if !gr.featureWrite {
+		return echo.NewHTTPError(http.StatusForbidden, "write is disabled")
+	}
+
 	session, err := getSession(c)
 	if err != nil {
 		log.Printf("error: failed to get session: %v\n", err)

--- a/src/handler/v1/game_role_test.go
+++ b/src/handler/v1/game_role_test.go
@@ -27,6 +27,10 @@ func TestPostMaintainer(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameAuthService := mock.NewMockGameAuth(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
@@ -272,6 +276,10 @@ func TestGetMaintainer(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameAuthService := mock.NewMockGameAuth(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.

--- a/src/handler/v1/game_role_test.go
+++ b/src/handler/v1/game_role_test.go
@@ -26,6 +26,7 @@ func TestPostMaintainer(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockGameAuthService := mock.NewMockGameAuth(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
@@ -47,7 +48,7 @@ func TestPostMaintainer(t *testing.T) {
 		return
 	}
 
-	gameRoleHandler := NewGameRole(session, mockGameAuthService)
+	gameRoleHandler := NewGameRole(mockAppConfig, session, mockGameAuthService)
 
 	type test struct {
 		description                 string
@@ -270,6 +271,7 @@ func TestGetMaintainer(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockGameAuthService := mock.NewMockGameAuth(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
@@ -291,7 +293,7 @@ func TestGetMaintainer(t *testing.T) {
 		return
 	}
 
-	gameRoleHandler := NewGameRole(session, mockGameAuthService)
+	gameRoleHandler := NewGameRole(mockAppConfig, session, mockGameAuthService)
 
 	type test struct {
 		description            string

--- a/src/handler/v1/game_test.go
+++ b/src/handler/v1/game_test.go
@@ -28,6 +28,10 @@ func TestPostGame(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -252,6 +256,10 @@ func TestGetGame(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -415,6 +423,10 @@ func TestPutGame(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -598,6 +610,10 @@ func TestGetGames(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -1098,6 +1114,10 @@ func TestDeleteGames(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().

--- a/src/handler/v1/game_test.go
+++ b/src/handler/v1/game_test.go
@@ -27,6 +27,7 @@ func TestPostGame(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -48,7 +49,7 @@ func TestPostGame(t *testing.T) {
 	}
 	mockGameService := mock.NewMockGame(ctrl)
 
-	gameHandler := NewGame(session, mockGameService)
+	gameHandler := NewGame(mockAppConfig, session, mockGameService)
 
 	type test struct {
 		description       string
@@ -250,6 +251,7 @@ func TestGetGame(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -271,7 +273,7 @@ func TestGetGame(t *testing.T) {
 	}
 	mockGameService := mock.NewMockGame(ctrl)
 
-	gameHandler := NewGame(session, mockGameService)
+	gameHandler := NewGame(mockAppConfig, session, mockGameService)
 
 	type test struct {
 		description    string
@@ -412,6 +414,7 @@ func TestPutGame(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -433,7 +436,7 @@ func TestPutGame(t *testing.T) {
 	}
 	mockGameService := mock.NewMockGame(ctrl)
 
-	gameHandler := NewGame(session, mockGameService)
+	gameHandler := NewGame(mockAppConfig, session, mockGameService)
 
 	type test struct {
 		description       string
@@ -594,6 +597,7 @@ func TestGetGames(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -615,7 +619,7 @@ func TestGetGames(t *testing.T) {
 	}
 	mockGameService := mock.NewMockGame(ctrl)
 
-	gameHandler := NewGame(session, mockGameService)
+	gameHandler := NewGame(mockAppConfig, session, mockGameService)
 
 	type test struct {
 		description       string
@@ -1093,6 +1097,7 @@ func TestDeleteGames(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockConf := mockConfig.NewMockHandler(ctrl)
 	mockConf.
 		EXPECT().
@@ -1114,7 +1119,7 @@ func TestDeleteGames(t *testing.T) {
 	}
 	mockGameService := mock.NewMockGame(ctrl)
 
-	gameHandler := NewGame(session, mockGameService)
+	gameHandler := NewGame(mockAppConfig, session, mockGameService)
 
 	type test struct {
 		description       string

--- a/src/handler/v1/game_url.go
+++ b/src/handler/v1/game_url.go
@@ -7,22 +7,29 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/trap-collection-server/src/config"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
 	"github.com/traPtitech/trap-collection-server/src/service"
 )
 
 type GameURL struct {
+	featureWrite   bool
 	gameURLService service.GameURL
 }
 
-func NewGameURL(gameURLService service.GameURL) *GameURL {
+func NewGameURL(appConf config.App, gameURLService service.GameURL) *GameURL {
 	return &GameURL{
+		featureWrite:   appConf.FeatureV1Write(),
 		gameURLService: gameURLService,
 	}
 }
 
 func (gu *GameURL) PostURL(c echo.Context, strGameID string, newGameURL *openapi.NewGameUrl) (*openapi.GameUrl, error) {
+	if !gu.featureWrite {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "v1 write is disabled")
+	}
+
 	ctx := c.Request().Context()
 
 	uuidGameID, err := uuid.Parse(strGameID)

--- a/src/handler/v1/game_url_test.go
+++ b/src/handler/v1/game_url_test.go
@@ -28,6 +28,10 @@ func TestPostURL(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameURLService := mock.NewMockGameURL(ctrl)
 
 	gameURLHandler := NewGameURL(mockAppConfig, mockGameURLService)
@@ -178,6 +182,10 @@ func TestGetGameURL(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameURLService := mock.NewMockGameURL(ctrl)
 
 	gameURLHandler := NewGameURL(mockAppConfig, mockGameURLService)

--- a/src/handler/v1/game_url_test.go
+++ b/src/handler/v1/game_url_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	mockConfig "github.com/traPtitech/trap-collection-server/src/config/mock"
 	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
@@ -26,9 +27,10 @@ func TestPostURL(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockGameURLService := mock.NewMockGameURL(ctrl)
 
-	gameURLHandler := NewGameURL(mockGameURLService)
+	gameURLHandler := NewGameURL(mockAppConfig, mockGameURLService)
 
 	type test struct {
 		description        string
@@ -175,9 +177,10 @@ func TestGetGameURL(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockGameURLService := mock.NewMockGameURL(ctrl)
 
-	gameURLHandler := NewGameURL(mockGameURLService)
+	gameURLHandler := NewGameURL(mockAppConfig, mockGameURLService)
 
 	type test struct {
 		description       string

--- a/src/handler/v1/game_version.go
+++ b/src/handler/v1/game_version.go
@@ -8,22 +8,29 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/trap-collection-server/src/config"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
 	"github.com/traPtitech/trap-collection-server/src/service"
 )
 
 type GameVersion struct {
+	featureWrite       bool
 	gameVersionService service.GameVersion
 }
 
-func NewGameVersion(gameVersionService service.GameVersion) *GameVersion {
+func NewGameVersion(appConf config.App, gameVersionService service.GameVersion) *GameVersion {
 	return &GameVersion{
+		featureWrite:       appConf.FeatureV1Write(),
 		gameVersionService: gameVersionService,
 	}
 }
 
 func (gv *GameVersion) PostGameVersion(c echo.Context, strGameID string, newGameVersion *openapi.NewGameVersion) (*openapi.GameVersion, error) {
+	if !gv.featureWrite {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "v1 write is disabled")
+	}
+
 	ctx := c.Request().Context()
 
 	uuidGameID, err := uuid.Parse(strGameID)

--- a/src/handler/v1/game_version_test.go
+++ b/src/handler/v1/game_version_test.go
@@ -27,6 +27,10 @@ func TestPostGameVersion(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameVersionService := mock.NewMockGameVersion(ctrl)
 
 	gameVersionHandler := NewGameVersion(mockAppConfig, mockGameVersionService)
@@ -227,6 +231,10 @@ func TestGetGameVersion(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameVersionService := mock.NewMockGameVersion(ctrl)
 
 	gameVersionHandler := NewGameVersion(mockAppConfig, mockGameVersionService)

--- a/src/handler/v1/game_version_test.go
+++ b/src/handler/v1/game_version_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	mockConfig "github.com/traPtitech/trap-collection-server/src/config/mock"
 	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
@@ -25,9 +26,10 @@ func TestPostGameVersion(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockGameVersionService := mock.NewMockGameVersion(ctrl)
 
-	gameVersionHandler := NewGameVersion(mockGameVersionService)
+	gameVersionHandler := NewGameVersion(mockAppConfig, mockGameVersionService)
 
 	type test struct {
 		description              string
@@ -224,9 +226,10 @@ func TestGetGameVersion(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockGameVersionService := mock.NewMockGameVersion(ctrl)
 
-	gameVersionHandler := NewGameVersion(mockGameVersionService)
+	gameVersionHandler := NewGameVersion(mockAppConfig, mockGameVersionService)
 
 	type test struct {
 		description           string

--- a/src/handler/v1/game_video.go
+++ b/src/handler/v1/game_video.go
@@ -10,21 +10,28 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/trap-collection-server/src/config"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/service"
 )
 
 type GameVideo struct {
+	featureWrite     bool
 	gameVideoService service.GameVideo
 }
 
-func NewGameVideo(gameVideoService service.GameVideo) *GameVideo {
+func NewGameVideo(appConf config.App, gameVideoService service.GameVideo) *GameVideo {
 	return &GameVideo{
+		featureWrite:     appConf.FeatureV1Write(),
 		gameVideoService: gameVideoService,
 	}
 }
 
 func (gv *GameVideo) PostVideo(c echo.Context, strGameID string, video multipart.File) error {
+	if !gv.featureWrite {
+		return echo.NewHTTPError(http.StatusForbidden, "v1 write is disabled")
+	}
+
 	ctx := c.Request().Context()
 
 	uuidGameID, err := uuid.Parse(strGameID)

--- a/src/handler/v1/game_video_test.go
+++ b/src/handler/v1/game_video_test.go
@@ -26,6 +26,10 @@ func TestPostVideo(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConf.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameVideoService := mock.NewMockGameVideo(ctrl)
 
 	gameVideoHandler := NewGameVideo(mockAppConfig, mockGameVideoService)
@@ -139,6 +143,10 @@ func TestGetVideo(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConf.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockGameVideoService := mock.NewMockGameVideo(ctrl)
 
 	gameVideoHandler := NewGameVideo(mockAppConfig, mockGameVideoService)

--- a/src/handler/v1/game_video_test.go
+++ b/src/handler/v1/game_video_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	mockConf "github.com/traPtitech/trap-collection-server/src/config/mock"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/service"
 	"github.com/traPtitech/trap-collection-server/src/service/mock"
@@ -24,9 +25,10 @@ func TestPostVideo(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConf.NewMockApp(ctrl)
 	mockGameVideoService := mock.NewMockGameVideo(ctrl)
 
-	gameVideoHandler := NewGameVideo(mockGameVideoService)
+	gameVideoHandler := NewGameVideo(mockAppConfig, mockGameVideoService)
 
 	type test struct {
 		description          string
@@ -136,9 +138,10 @@ func TestGetVideo(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConf.NewMockApp(ctrl)
 	mockGameVideoService := mock.NewMockGameVideo(ctrl)
 
-	gameVideoHandler := NewGameVideo(mockGameVideoService)
+	gameVideoHandler := NewGameVideo(mockAppConfig, mockGameVideoService)
 
 	type test struct {
 		description         string

--- a/src/handler/v1/launcher_auth_test.go
+++ b/src/handler/v1/launcher_auth_test.go
@@ -31,6 +31,10 @@ func TestPostKeyGenerate(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
 
 	launcherAuthHandler := NewLauncherAuth(mockAppConfig, mockLauncherAuthService)
@@ -223,6 +227,10 @@ func TestPostLauncherLogin(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
 
 	launcherAuthHandler := NewLauncherAuth(mockAppConfig, mockLauncherAuthService)
@@ -355,6 +363,10 @@ func TestDeleteProductKey(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
 
 	launcherAuthHandler := NewLauncherAuth(mockAppConfig, mockLauncherAuthService)
@@ -456,6 +468,10 @@ func TestGetProductKeys(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
 
 	launcherAuthHandler := NewLauncherAuth(mockAppConfig, mockLauncherAuthService)
@@ -621,6 +637,10 @@ func TestGetLauncherMe(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
 
 	launcherAuthHandler := NewLauncherAuth(mockAppConfig, mockLauncherAuthService)

--- a/src/handler/v1/launcher_auth_test.go
+++ b/src/handler/v1/launcher_auth_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	mockConfig "github.com/traPtitech/trap-collection-server/src/config/mock"
 	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
@@ -29,9 +30,10 @@ func TestPostKeyGenerate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
 
-	launcherAuthHandler := NewLauncherAuth(mockLauncherAuthService)
+	launcherAuthHandler := NewLauncherAuth(mockAppConfig, mockLauncherAuthService)
 
 	type test struct {
 		description               string
@@ -220,9 +222,10 @@ func TestPostLauncherLogin(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
 
-	launcherAuthHandler := NewLauncherAuth(mockLauncherAuthService)
+	launcherAuthHandler := NewLauncherAuth(mockAppConfig, mockLauncherAuthService)
 
 	type test struct {
 		description          string
@@ -351,9 +354,10 @@ func TestDeleteProductKey(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
 
-	launcherAuthHandler := NewLauncherAuth(mockLauncherAuthService)
+	launcherAuthHandler := NewLauncherAuth(mockAppConfig, mockLauncherAuthService)
 
 	type test struct {
 		description             string
@@ -451,9 +455,10 @@ func TestGetProductKeys(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
 
-	launcherAuthHandler := NewLauncherAuth(mockLauncherAuthService)
+	launcherAuthHandler := NewLauncherAuth(mockAppConfig, mockLauncherAuthService)
 
 	type test struct {
 		description              string
@@ -615,9 +620,10 @@ func TestGetLauncherMe(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockLauncherAuthService := mock.NewMockLauncherAuth(ctrl)
 
-	launcherAuthHandler := NewLauncherAuth(mockLauncherAuthService)
+	launcherAuthHandler := NewLauncherAuth(mockAppConfig, mockLauncherAuthService)
 
 	type test struct {
 		description     string

--- a/src/handler/v1/launcher_version.go
+++ b/src/handler/v1/launcher_version.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/trap-collection-server/src/config"
 	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
@@ -18,11 +19,13 @@ import (
 )
 
 type LauncherVersion struct {
+	featureWrite           bool
 	launcherVersionService service.LauncherVersion
 }
 
-func NewLauncherVersion(launcherVersionService service.LauncherVersion) *LauncherVersion {
+func NewLauncherVersion(appConf config.App, launcherVersionService service.LauncherVersion) *LauncherVersion {
 	return &LauncherVersion{
+		featureWrite:           appConf.FeatureV1Write(),
 		launcherVersionService: launcherVersionService,
 	}
 }
@@ -61,6 +64,10 @@ func (lv *LauncherVersion) GetVersions(c echo.Context) ([]*openapi.Version, erro
 }
 
 func (lv *LauncherVersion) PostVersion(c echo.Context, newVersion *openapi.NewVersion) (*openapi.VersionMeta, error) {
+	if !lv.featureWrite {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "write feature is disabled")
+	}
+
 	ctx := c.Request().Context()
 
 	name := values.NewLauncherVersionName(newVersion.Name)
@@ -160,6 +167,10 @@ func (lv *LauncherVersion) GetVersion(c echo.Context, strLauncherVersionID strin
 }
 
 func (lv *LauncherVersion) PostGameToVersion(c echo.Context, strLauncherVersionID string, apiGameIDs *openapi.GameIDs) (*openapi.VersionDetails, error) {
+	if !lv.featureWrite {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "write feature is disabled")
+	}
+
 	ctx := c.Request().Context()
 
 	uuidLauncherVersionID, err := uuid.Parse(strLauncherVersionID)

--- a/src/handler/v1/launcher_version_test.go
+++ b/src/handler/v1/launcher_version_test.go
@@ -28,6 +28,10 @@ func TestGetVersions(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockLauncherVersionService := mock.NewMockLauncherVersion(ctrl)
 
 	launcherVersionHandler := NewLauncherVersion(mockAppConfig, mockLauncherVersionService)
@@ -182,6 +186,10 @@ func TestPostVersion(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockLauncherVersionService := mock.NewMockLauncherVersion(ctrl)
 
 	launcherVersionHandler := NewLauncherVersion(mockAppConfig, mockLauncherVersionService)
@@ -335,6 +343,10 @@ func TestGetVersion(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockLauncherVersionService := mock.NewMockLauncherVersion(ctrl)
 
 	launcherVersionHandler := NewLauncherVersion(mockAppConfig, mockLauncherVersionService)
@@ -572,6 +584,10 @@ func TestPostGameToVersion(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockLauncherVersionService := mock.NewMockLauncherVersion(ctrl)
 
 	launcherVersionHandler := NewLauncherVersion(mockAppConfig, mockLauncherVersionService)
@@ -842,6 +858,10 @@ func TestGetCheckList(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockAppConfig := mockConfig.NewMockApp(ctrl)
+	mockAppConfig.
+		EXPECT().
+		FeatureV1Write().
+		Return(true)
 	mockLauncherVersionService := mock.NewMockLauncherVersion(ctrl)
 
 	launcherVersionHandler := NewLauncherVersion(mockAppConfig, mockLauncherVersionService)

--- a/src/handler/v1/launcher_version_test.go
+++ b/src/handler/v1/launcher_version_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	mockConfig "github.com/traPtitech/trap-collection-server/src/config/mock"
 	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
 	"github.com/traPtitech/trap-collection-server/src/handler/v1/openapi"
@@ -26,9 +27,10 @@ func TestGetVersions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockLauncherVersionService := mock.NewMockLauncherVersion(ctrl)
 
-	launcherVersionHandler := NewLauncherVersion(mockLauncherVersionService)
+	launcherVersionHandler := NewLauncherVersion(mockAppConfig, mockLauncherVersionService)
 
 	type test struct {
 		description            string
@@ -179,9 +181,10 @@ func TestPostVersion(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockLauncherVersionService := mock.NewMockLauncherVersion(ctrl)
 
-	launcherVersionHandler := NewLauncherVersion(mockLauncherVersionService)
+	launcherVersionHandler := NewLauncherVersion(mockAppConfig, mockLauncherVersionService)
 
 	type test struct {
 		description                  string
@@ -331,9 +334,10 @@ func TestGetVersion(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockLauncherVersionService := mock.NewMockLauncherVersion(ctrl)
 
-	launcherVersionHandler := NewLauncherVersion(mockLauncherVersionService)
+	launcherVersionHandler := NewLauncherVersion(mockAppConfig, mockLauncherVersionService)
 
 	type test struct {
 		description               string
@@ -567,9 +571,10 @@ func TestPostGameToVersion(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockLauncherVersionService := mock.NewMockLauncherVersion(ctrl)
 
-	launcherVersionHandler := NewLauncherVersion(mockLauncherVersionService)
+	launcherVersionHandler := NewLauncherVersion(mockAppConfig, mockLauncherVersionService)
 
 	type test struct {
 		description                      string
@@ -836,9 +841,10 @@ func TestGetCheckList(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAppConfig := mockConfig.NewMockApp(ctrl)
 	mockLauncherVersionService := mock.NewMockLauncherVersion(ctrl)
 
-	launcherVersionHandler := NewLauncherVersion(mockLauncherVersionService)
+	launcherVersionHandler := NewLauncherVersion(mockAppConfig, mockLauncherVersionService)
 
 	type test struct {
 		description                        string

--- a/src/wire/wire_gen.go
+++ b/src/wire/wire_gen.go
@@ -137,8 +137,8 @@ func InjectApp() (*App, error) {
 	user2 := v1_2.NewUser(v1Session, v1User)
 	gameVersion := gorm2.NewGameVersion(db)
 	v1Game := v1_3.NewGame(db, game, gameVersion, gameManagementRole, userUtils)
-	game2 := v1_2.NewGame(v1Session, v1Game)
-	gameRole := v1_2.NewGameRole(v1Session, gameAuth)
+	game2 := v1_2.NewGame(app, v1Session, v1Game)
+	gameRole := v1_2.NewGameRole(app, v1Session, gameAuth)
 	gameImage := gorm2.NewGameImage(db)
 	storage := v1.NewStorage()
 	storageSwift := v1.NewStorageSwift()
@@ -150,23 +150,23 @@ func InjectApp() (*App, error) {
 	}
 	storageGameImage := wireStorage.GameImage
 	v1GameImage := v1_3.NewGameImage(db, game, gameImage, storageGameImage)
-	gameImage2 := v1_2.NewGameImage(v1GameImage)
+	gameImage2 := v1_2.NewGameImage(app, v1GameImage)
 	gameVideo := gorm2.NewGameVideo(db)
 	storageGameVideo := wireStorage.GameVideo
 	v1GameVideo := v1_3.NewGameVideo(db, game, gameVideo, storageGameVideo)
-	gameVideo2 := v1_2.NewGameVideo(v1GameVideo)
+	gameVideo2 := v1_2.NewGameVideo(app, v1GameVideo)
 	v1GameVersion := v1_3.NewGameVersion(db, game, gameVersion)
-	gameVersion2 := v1_2.NewGameVersion(v1GameVersion)
+	gameVersion2 := v1_2.NewGameVersion(app, v1GameVersion)
 	gameFile := gorm2.NewGameFile(db)
 	storageGameFile := wireStorage.GameFile
 	v1GameFile := v1_3.NewGameFile(db, game, gameVersion, gameFile, storageGameFile)
-	gameFile2 := v1_2.NewGameFile(v1GameFile)
+	gameFile2 := v1_2.NewGameFile(app, v1GameFile)
 	gameURL := gorm2.NewGameURL(db)
 	v1GameURL := v1_3.NewGameURL(db, game, gameVersion, gameURL)
-	gameURL2 := v1_2.NewGameURL(v1GameURL)
-	v1LauncherAuth := v1_2.NewLauncherAuth(launcherAuth)
+	gameURL2 := v1_2.NewGameURL(app, v1GameURL)
+	v1LauncherAuth := v1_2.NewLauncherAuth(app, launcherAuth)
 	v1LauncherVersion := v1_3.NewLauncherVersion(db, launcherVersion, game)
-	launcherVersion2 := v1_2.NewLauncherVersion(v1LauncherVersion)
+	launcherVersion2 := v1_2.NewLauncherVersion(app, v1LauncherVersion)
 	oAuth2, err := v1_2.NewOAuth2(v1Handler, v1Session, v1OIDC)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
v1の書き込み系apiを停止する環境変数`FEATURE_V1_WRITE`を作った。
この環境変数にfalseを設定すると、
認証系を除いてpost、delete、patchのapiを使えなくなる。
v1からv2への移行用に設定。
デフォルトはtrueなので、デフォルトの動作に変更はない。