### PR TITLE
v8のmigration修正

### DIFF
--- a/src/repository/gorm2/migrate/v8.go
+++ b/src/repository/gorm2/migrate/v8.go
@@ -48,11 +48,11 @@ func v8() *gormigrate.Migration {
 				"FROM game_versions " +
 				"LEFT JOIN games ON game_versions.game_id = games.id " +
 				"LEFT JOIN (SELECT * FROM game_images AS gi1 WHERE id = (" +
-				"SELECT id FROM game_images AS gi2 WHERE gi1.game_id = gi2.game_id ORDER BY gi2.created_at LIMIT 1" +
+				"SELECT id FROM game_images AS gi2 WHERE gi1.game_id = gi2.game_id ORDER BY gi2.created_at DESC LIMIT 1" +
 				")) AS game_images ON games.id = game_images.game_id " +
 				"LEFT JOIN (SELECT * FROM game_videos AS gv1 WHERE id = (" +
-				"SELECT id FROM game_videos AS gv2 WHERE gv1.game_id = gv2.game_id ORDER BY gv2.created_at LIMIT 1)" +
-				") AS game_videos ON games.id = game_videos.game_id " +
+				"SELECT id FROM game_videos AS gv2 WHERE gv1.game_id = gv2.game_id ORDER BY gv2.created_at DESC LIMIT 1" +
+				")) AS game_videos ON games.id = game_videos.game_id " +
 				"LEFT JOIN game_urls ON game_versions.id = game_urls.game_version_id").Error
 			if err != nil {
 				return fmt.Errorf("failed to migrate v2_game_versions table: %w", err)
@@ -81,7 +81,7 @@ func v8() *gormigrate.Migration {
 				"(edition_id, game_version_id) " +
 				"SELECT launcher_version_game_relations.launcher_version_table_id, game_versions.id " +
 				"FROM launcher_version_game_relations " +
-				"LEFT JOIN (SELECT * FROM game_versions AS gv1 WHERE id = (SELECT id FROM game_versions AS gv2 WHERE gv1.game_id = gv2.game_id ORDER BY gv2.created_at LIMIT 1)) AS game_versions ON launcher_version_game_relations.game_table_id = game_versions.game_id").Error
+				"LEFT JOIN (SELECT * FROM game_versions AS gv1 WHERE id = (SELECT id FROM game_versions AS gv2 WHERE gv1.game_id = gv2.game_id ORDER BY gv2.created_at DESC LIMIT 1)) AS game_versions ON launcher_version_game_relations.game_table_id = game_versions.game_id").Error
 			if err != nil {
 				return fmt.Errorf("failed to migrate edition_game_version_relations table: %w", err)
 			}

--- a/src/service/v2/edition.go
+++ b/src/service/v2/edition.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/traPtitech/trap-collection-server/pkg/types"
 	"github.com/traPtitech/trap-collection-server/src/domain"
 	"github.com/traPtitech/trap-collection-server/src/domain/values"
@@ -328,7 +327,6 @@ func (edition *Edition) GetEditionGameVersions(ctx context.Context, editionID va
 		gameIDs = append(gameIDs, gameVersion.GameID)
 		fileIDs = append(fileIDs, gameVersion.FileIDs...)
 	}
-	log.Printf("game_ids: %d, %+v\n", len(gameIDs), gameIDs)
 
 	games, err := edition.gameRepository.GetGamesByIDs(ctx, gameIDs, repository.LockTypeNone)
 	if err != nil {
@@ -339,7 +337,6 @@ func (edition *Edition) GetEditionGameVersions(ctx context.Context, editionID va
 	for _, game := range games {
 		gameMap[game.GetID()] = game
 	}
-	log.Printf("game_map: %d, %+v\n", len(gameMap), gameMap)
 
 	files, err := edition.gameFileRepository.GetGameFilesWithoutTypes(ctx, fileIDs, repository.LockTypeNone)
 	if err != nil {
@@ -355,7 +352,6 @@ func (edition *Edition) GetEditionGameVersions(ctx context.Context, editionID va
 	for _, gameVersion := range gameVersions {
 		game, ok := gameMap[gameVersion.GameID]
 		if !ok {
-			log.Printf("game_id(false): %s\n", uuid.UUID(gameVersion.GameID))
 			return nil, errors.New("game not found")
 		}
 


### PR DESCRIPTION
`created_at`での`ORDER BY`が全て`DESC`が抜けており、
最新ではなく最も古い画像、動画がゲームバージョンに紐づき、
最も古いゲームバージョンがエディションに紐づいていた。