### PR TITLE
repositoryのUpdateEditionでのgormのupdateメソッドの書き方を変更

### DIFF
--- a/src/repository/gorm2/edition.go
+++ b/src/repository/gorm2/edition.go
@@ -88,7 +88,8 @@ func (e *Edition) UpdateEdition(ctx context.Context, edition *domain.LauncherVer
 		}
 	}
 
-	result := db.
+	result := db.Model(&migrate.EditionTable2{}).
+		Select("name", "questionnaire_url").
 		Where("id = ?", uuid.UUID(edition.GetID())).
 		Updates(migrate.EditionTable2{
 			Name:             string(edition.GetName()),


### PR DESCRIPTION
Selectで明示的に更新対象のフィールドの指定を行うようにした
https://gorm.io/docs/update.html#Update-Selected-Fields

sql.NullStringでValidがfalseのもの(ゼロ値の状態)は、普通の書き方だとUpdateの対象とならないため
>NOTE When updating with struct, GORM will only update non-zero fields. You might want to use map to update attributes or use Select to specify fields to update
https://gorm.io/docs/update.html#Updates-multiple-columns


