### PR TITLE
checkerのエラーのstatusコードが全て403になっていた

### DIFF
--- a/src/handler/v2/checker.go
+++ b/src/handler/v2/checker.go
@@ -69,7 +69,9 @@ func (checker *Checker) check(ctx context.Context, input *openapi3filter.Authent
 
 	err := checkerFunc(ctx, input)
 	if err != nil {
-		return fmt.Errorf("failed to check security scheme: %w", err)
+		// fmt.Errorfでwrapすると*echo.HTTPError型でなくなりstatus codeが403になってしまうので、
+		// ここではwrapしてはいけない
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
errorをwrapしたことで`*echo.HTTPError`型でなくなってしまい、
https://github.com/deepmap/oapi-codegen/blob/ab90f1927bc5ec3e29af216d4298fbb4780ae36d/pkg/middleware/oapi_validate.go#L169
に引っかからなくなっていた。
echo的にも`*echo.HTTPError`をwrapするのはあまり良くなさそうなので、修正した。