### PR TITLE
adminのバグ修正

### DIFF
--- a/src/repository/errors.go
+++ b/src/repository/errors.go
@@ -7,4 +7,5 @@ var (
 	ErrNoRecordDeleted = errors.New("no record deleted")
 	ErrNoRecordUpdated = errors.New("no record updated")
 	ErrNegativeLimit   = errors.New("limit is negative")
+	ErrLastAdmin       = errors.New("last admin cannot be deleted")
 )

--- a/src/repository/gorm2/v2_admin_auth.go
+++ b/src/repository/gorm2/v2_admin_auth.go
@@ -62,6 +62,17 @@ func (aa *AdminAuth) DeleteAdmin(ctx context.Context, userID values.TraPMemberID
 		return fmt.Errorf("failed to get db: %w", err)
 	}
 
+	var adminsCount int64
+	err = db.
+		Table((&migrate.AdminTable{}).TableName()).
+		Count(&adminsCount).Error
+	if err != nil {
+		return fmt.Errorf("failed to count admins: %w", err)
+	}
+	if int(adminsCount) == 1 {
+		return repository.ErrLastAdmin
+	}
+
 	result := db.
 		Where("user_id = ?", uuid.UUID(userID)).
 		Delete(&migrate.AdminTable{})

--- a/src/repository/gorm2/v2_admin_auth_test.go
+++ b/src/repository/gorm2/v2_admin_auth_test.go
@@ -228,16 +228,6 @@ func TestDeleteAdminV2(t *testing.T) {
 				{
 					UserID: uuid.UUID(traPMemberID1),
 				},
-			},
-			afterAdminMap: map[values.TraPMemberID]struct{}{},
-		},
-		{
-			description: "他のadminが存在してもエラーなし",
-			userID:      traPMemberID1,
-			beforeAdmins: []migrate.AdminTable{
-				{
-					UserID: uuid.UUID(traPMemberID1),
-				},
 				{
 					UserID: uuid.UUID(traPMemberID2),
 				},
@@ -245,6 +235,20 @@ func TestDeleteAdminV2(t *testing.T) {
 			afterAdminMap: map[values.TraPMemberID]struct{}{
 				traPMemberID2: {},
 			},
+		},
+		{
+			description: "最後の一人なのでErrLastAdmin",
+			userID:      traPMemberID1,
+			beforeAdmins: []migrate.AdminTable{
+				{
+					UserID: uuid.UUID(traPMemberID1),
+				},
+			},
+			afterAdminMap: map[values.TraPMemberID]struct{}{
+				traPMemberID2: {},
+			},
+			isErr: true,
+			err:   repository.ErrLastAdmin,
 		},
 		{
 			description:   "adminが存在しないのでErrNoRecordDeleted",

--- a/src/repository/v2_admin_auth.go
+++ b/src/repository/v2_admin_auth.go
@@ -18,5 +18,6 @@ type AdminAuthV2 interface {
 	//DeleteAdmin
 	//adminを削除
 	//ユーザーが存在しない場合、ErrNoRecordDeletedを返す。
+	//最後の管理者を削除しようとした場合、ErrLastAdminを返す。
 	DeleteAdmin(ctx context.Context, userID values.TraPMemberID) error
 }

--- a/src/service/v2/admin_auth.go
+++ b/src/service/v2/admin_auth.go
@@ -91,7 +91,7 @@ func (aa *AdminAuth) GetAdmins(ctx context.Context, session *domain.OIDCSession)
 		return nil, fmt.Errorf("failed to get admins: %w", err)
 	}
 
-	adminsInfo := make([]*service.UserInfo, len(adminIDs))
+	adminsInfo := make([]*service.UserInfo, 0, len(adminIDs))
 	for _, adminID := range adminIDs {
 		if adminInfo, ok := activeUsersMap[adminID]; ok {
 			adminsInfo = append(adminsInfo, adminInfo)
@@ -127,7 +127,7 @@ func (aa *AdminAuth) DeleteAdmin(ctx context.Context, session *domain.OIDCSessio
 		return nil, fmt.Errorf("failed to get admins: %w", err)
 	}
 
-	adminsInfo := make([]*service.UserInfo, len(adminIDs))
+	adminsInfo := make([]*service.UserInfo, 0, len(adminIDs))
 	for _, adminID := range adminIDs {
 		if adminInfo, ok := activeUsersMap[adminID]; ok {
 			adminsInfo = append(adminsInfo, adminInfo)

--- a/src/service/v2/admin_auth.go
+++ b/src/service/v2/admin_auth.go
@@ -118,6 +118,9 @@ func (aa *AdminAuth) DeleteAdmin(ctx context.Context, session *domain.OIDCSessio
 	if errors.Is(err, repository.ErrNoRecordDeleted) {
 		return nil, service.ErrNotAdmin
 	}
+	if errors.Is(err, repository.ErrLastAdmin) {
+		return nil, service.ErrLastAdmin
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete admin: %w", err)
 	}

--- a/src/service/v2_admin_auth.go
+++ b/src/service/v2_admin_auth.go
@@ -22,6 +22,7 @@ type AdminAuthV2 interface {
 	//adminを削除
 	//ユーザーが存在しないとき、ErrInvalidUserIDを返す。
 	//ユーザーがadminでないとき、ErrNotAdminを返す。
+	//最後の管理者を削除しようとしたとき、ErrLastAdminを返す。
 	DeleteAdmin(ctx context.Context, session *domain.OIDCSession, userID values.TraPMemberID) ([]*UserInfo, error)
 	//AdminAuthorize
 	//ログイン中のユーザーがadminかどうか判断する。

--- a/src/service/v2_errors.go
+++ b/src/service/v2_errors.go
@@ -11,4 +11,5 @@ var (
 	ErrCannotEditOwners                   = errors.New("cannot update role bacause there is only 1 owner")
 	ErrNoAdminsUpdated                    = errors.New("no admins updated")
 	ErrNotAdmin                           = errors.New("not admin")
+	ErrLastAdmin                          = errors.New("last admin cannot be deleted")
 )


### PR DESCRIPTION
- 管理者の取得と削除で`make`関数の引数を間違ってnil pointerの参照が起きてたのを修正
- 最後の一人の管理者を削除できないように修正
    - repositoryにはテストが存在していたのでそちらも修正したが、serviceにはテストが存在していなかったので書いていない。そのうち書く。