### PR TITLE
ローカルの開発環境にwebui追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ CLIENT_SECRET={{traQのClientのClientSecret}}
 ```
 
 最後に以下のコマンドを実行することで開発環境がポート3000番で起動します。
+また、Web UIをhttp://localhost:8080 で開けるようになります。
 ```bash
 task dev
 ```

--- a/docker/dev/Caddyfile
+++ b/docker/dev/Caddyfile
@@ -1,0 +1,16 @@
+:80 {
+	handle /api* {
+		reverse_proxy /api* collection-server:3000
+	}
+
+	handle {
+		encode zstd gzip
+
+		file_server {
+				precompressed br gzip
+		}
+		root * /usr/share/caddy
+
+		try_files {path} /index.html
+	}
+}

--- a/docker/dev/compose.yaml
+++ b/docker/dev/compose.yaml
@@ -1,4 +1,10 @@
 services:
+  collection-proxy:
+    build:
+      context: .
+      dockerfile: proxy.Dockerfile
+    ports:
+      - 8080:80
   collection-server:
     extends:
       file: ../base/compose.yaml

--- a/docker/dev/proxy.Dockerfile
+++ b/docker/dev/proxy.Dockerfile
@@ -1,0 +1,7 @@
+# syntax = docker/dockerfile:1
+
+FROM caddy:2.4.6
+
+COPY Caddyfile /etc/caddy/Caddyfile
+RUN wget -O - https://github.com/traPtitech/trap-collection-admin/releases/latest/download/dist.tar.gz \
+  | tar zxv -C /usr/share/caddy --strip-components=2


### PR DESCRIPTION
追加した。
`http://localhost:8080`を開くことでWebUIにアクセスできる。
Caddyでプロキシして、Web UIの静的配信とサーバーに振り分けている。
現時点では、初期adminの追加がないためdb直いじりで初期adminの追加をしないadminになれない。
Close #525 