### PR TITLE
GitHub Actionsからoapi-codegenのコード生成削除

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      - run: go generate ./src/handler/v2/api.go
       - run: go build -o collection
   test:
     name: Test


### PR DESCRIPTION
#559 によりoapi-codegenの生成ファイルを含めたため、GitHub Actionsからoapi-codegenのコード生成を除外した。