### PR TITLE
:wrench: CodeCovのsecretを使う

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: codecov/codecov-action@v4.1.0
         with:
           file: /tmp/coverage/coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v4
         with:
           name: coverage.txt


### PR DESCRIPTION
codecovのGitHub Actionがv4になったときにtokenが必要になった

https://github.com/codecov/codecov-action?tab=readme-ov-file#breaking-changes