### PR TITLE
docker composeのdepends_onを削除

### DIFF
--- a/docker/base/compose.yaml
+++ b/docker/base/compose.yaml
@@ -15,9 +15,6 @@ services:
       S3_ENDPOINT: http://s3:9000
       S3_USE_PATH_STYLE: false
       PORT: :3000
-    depends_on:
-      mariadb:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:3000/api/metrics"]
       timeout: 5m


### PR DESCRIPTION
### **User description**
extendsを使ったときにdepends_onを使えなくなっていたので、削除した。


___

### **PR Type**
configuration changes


___

### **Description**
- `docker/base/compose.yaml`ファイルから`depends_on`セクションを削除し、`mariadb`サービスの依存関係を解消しました。
- `extends`を使用する際に`depends_on`が使えない問題に対処しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compose.yaml</strong><dd><code>`depends_on`セクションの削除による依存関係の解消</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/base/compose.yaml

- `depends_on`セクションを削除
- `mariadb`サービスの依存関係を削除



</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/988/files#diff-0fa466351fcfa5bc7d11f51258cde26efaceb87124795ac8e89d04a3774fdaa6">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

