### PR TITLE
:wrench: ai reviewで自動生成されるコードを無視するように設定

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -34,3 +34,4 @@ jobs:
           PR_DESCRIPTION.ADD_ORIGINAL_USER_DESCRIPTION: "true"
           PR_DESCRIPTION.EXTRA_INSTRUCTIONS: "Please use Japanese in descriptions."
           PR_CODE_SUGGESTIONS.EXTRA_INSTRUCTIONS: "Please use Japanese in descriptions."
+          IGNORE.GLOB: "['*.gen.go']"


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- `.github/workflows/ai-review.yaml`において、`IGNORE.GLOB`に`['*.gen.go']`を追加し、自動生成されるGoコードを無視するように設定を変更。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai-review.yaml</strong><dd><code>自動生成コードを無視する設定の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ai-review.yaml

- `IGNORE.GLOB`に`['*.gen.go']`を追加



</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/990/files#diff-1da0bf33aceeb4a1d8353a9d5d7e382f4f164f0d51e0a276aa0d7ee351c146f9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

