### PR TITLE
:wrench: deprecatedだったfail_on_errorをfail_levelに変更

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
           go_version_file: go.mod
           reporter: github-pr-check
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          fail_on_error: true
+          fail_level: any
   spectral:
     name: Spectral
     runs-on: ubuntu-latest


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- `.github/workflows/ci.yaml`内で、非推奨となった`fail_on_error`を`fail_level`に変更しました。
- `reviewdog/action-golangci-lint`の設定を最新の推奨形式に更新しました。



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yaml</strong><dd><code>非推奨の`fail_on_error`を`fail_level`に置き換え</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yaml

<li><code>fail_on_error</code>が非推奨となったため、<code>fail_level</code>に変更。<br> <li> <code>reviewdog/action-golangci-lint</code>の設定を更新。


</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/1084/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information