### PR TITLE
:bug: editionテーブルの参照するスキーマを修正

### DIFF
--- a/src/repository/gorm2/migrate/current.go
+++ b/src/repository/gorm2/migrate/current.go
@@ -48,7 +48,7 @@ type (
 	GameFileTable2          = gameFileTable2V5
 	GameImageTable2         = gameImageTable2V2
 	GameVideoTable2         = gameVideoTable2V2
-	EditionTable2           = editionTableV6
+	EditionTable2           = editionTableV15
 	ProductKeyTable2        = productKeyTableV6
 	ProductKeyStatusTable2  = productKeyStatusTableV6
 	AccessTokenTable2       = accessTokenTableV2


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- 修正対象の`EditionTable2`が誤ったスキーマを参照していた問題を修正

- `editionTableV6`から`editionTableV15`への参照を変更


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>current.go</strong><dd><code>`EditionTable2`のスキーマ参照を修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/repository/gorm2/migrate/current.go

- `EditionTable2`の参照を`editionTableV6`から`editionTableV15`に変更


</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/1137/files#diff-804bdb66488b73d682ce97fff2da46506c624a2f4d24ff6b81361d960bee56c0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>