### PR TITLE
開発環境のDBのvolumeを移動

### DIFF
--- a/docker/dev/compose.yaml
+++ b/docker/dev/compose.yaml
@@ -35,7 +35,7 @@ services:
     ports:
       - 3306:3306
     volumes:
-      - ../../mysql/data:/var/lib/mysql
+      - trap_collection_mysql_data:/var/lib/mysql
   adminer:
     image: adminer:latest
     restart: always
@@ -43,3 +43,6 @@ services:
       ADMINER_DEFAULT_SERVER: mariadb
     ports:
       - 8081:8080
+
+volumes:
+  trap_collection_mysql_data:

--- a/task/Taskfile_unix.yml
+++ b/task/Taskfile_unix.yml
@@ -69,7 +69,7 @@ tasks:
   clean:db:
     dir: ../
     cmds:
-      - rm -rf mysql/data
+      - docker volume rm dev_trap_collection_mysql_data
 
   update-frontend:
     dir: ../

--- a/task/Taskfile_windows.yml
+++ b/task/Taskfile_windows.yml
@@ -69,7 +69,7 @@ tasks:
   clean:db:
     dir: ..\
     cmds:
-      - del .\mysql\data
+      - docker volume rm dev_trap_collection_mysql_data
 
   update-frontend:
     dir: ..\


### PR DESCRIPTION
### **User description**
fix #1204

今までリポジトリルートのmysqlディレクトリにあったが、root権限でディレクトリが作られてしまうため、一部のコマンドが実行できないなど不便があった。

- **:wrench: dev環境のdocker composeでDBのvolumenを移動**
- **:wrench: DBをリセットするコマンドの修正**


___

### **PR Type**
Enhancement


___

### **Description**
- 開発環境Dockerボリュームを名前付きに変更

- compose.yamlで`trap_collection_mysql_data`追加

- clean:dbコマンドをボリューム削除に更新

- Unix/Windows両Taskfile対応


___

### **Changes diagram**

```mermaid
flowchart LR
  A["docker/dev/compose.yaml"] -- "バインドマウント削除" --> B["trap_collection_mysql_data"]
  C["Taskfile_*"]          -- "clean:dbコマンド更新" --> B
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compose.yaml</strong><dd><code>MariaDBデータボリューム設定更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/dev/compose.yaml

<li>バインドマウント<code>../../mysql/data</code>を削除<br> <li> 名前付きボリューム<code>trap_collection_mysql_data</code>を追加<br> <li> <code>volumes:</code>定義をファイル末尾に配置


</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/1280/files#diff-6fedbd02b733618eacd9c4534b861c1544bd3647d685e963e8679bd05238aff8">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Taskfile_unix.yml</strong><dd><code>Unix用DBリセットコマンド更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

task/Taskfile_unix.yml

<li><code>clean:db</code>コマンドをホスト削除からボリューム削除に変更<br> <li> ボリューム名を<code>dev_trap_collection_mysql_data</code>に更新


</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/1280/files#diff-beb4f244b871326f88c5f4cafd30daa1137ce34e0445edc9197ad66659e78878">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Taskfile_windows.yml</strong><dd><code>Windows用DBリセットコマンド更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

task/Taskfile_windows.yml

<li><code>clean:db</code>コマンドをファイル削除からボリューム削除に変更<br> <li> ボリューム名を<code>dev_trap_collection_mysql_data</code>に指定


</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/1280/files#diff-4f05608fdde7c3d39086582d6281161abb04a994e82e494985eac8b70dd82084">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>