### PR TITLE
:wrench: reviewdogのreporterをPRかそれ以外かで切り替え

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2.8
         with:
           go_version_file: go.mod
-          reporter: github-pr-check
+          reporter: ${{ github.event_name == 'pull_request' && 'github-pr-review' || 'github-check' }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_level: any
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- CIでreviewdog reporterを動的切替

- PR時はgithub-pr-reviewを使用

- 非PR時はgithub-checkを使用


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Event"] --> B{"event_name == pull_request"}
  B -- "Yes" --> C["reporter = github-pr-review"]
  B -- "No" --> D["reporter = github-check"]
  C --> E["reviewdog/action-golangci-lint"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yaml</strong><dd><code>reviewdog reporterの動的条件切替を導入</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yaml

<ul><li>reviewdog reporterを条件式で設定<br> <li> PR時にgithub-pr-reviewへ変更<br> <li> 非PR時にgithub-checkを使用</ul>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/1372/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

