### PR TITLE
CIの高速化

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: build
+    if: ${{ always() }}
     services:
       dind:
         image: docker:23.0-rc-dind-rootless
@@ -53,6 +55,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       # go generate用に、golangci-lintの前にGoのinstallをする


### PR DESCRIPTION
### **User description**
testとlintでビルドキャッシュが使えるようにする


___

### **PR Type**
Enhancement


___

### **Description**
- CIでbuildを先行実行

- testをbuildに依存させる

- lintをbuildに依存させる

- testを常時実行に変更


___

### Diagram Walkthrough


```mermaid
flowchart LR
  build["Build job"] --> test["Test job (always)"]
  build --> lint["Lint job"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yaml</strong><dd><code>Test/LintをBuild依存にし実行順序を整理</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yaml

<ul><li>testにneeds: buildを追加<br> <li> testにif: ${{ always() }}を追加<br> <li> lintにneeds: buildを追加<br> <li> 実行順序をbuild→test/lintへ整備</ul>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/1374/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133dd">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

