### PR TITLE
パッケージ名重複エラーでLintが落ちているのを修正する

### DIFF
--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -1,4 +1,4 @@
-package context
+package ctxkeys
 
 type Key int
 

--- a/src/repository/gorm2/db.go
+++ b/src/repository/gorm2/db.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	pkgContext "github.com/traPtitech/trap-collection-server/pkg/context"
+	"github.com/traPtitech/trap-collection-server/pkg/context"
 	"github.com/traPtitech/trap-collection-server/src/config"
 	"github.com/traPtitech/trap-collection-server/src/repository"
 	"github.com/traPtitech/trap-collection-server/src/repository/gorm2/schema"
@@ -131,7 +131,7 @@ func (db *DB) Get() (*sql.DB, error) {
 
 func (db *DB) Transaction(ctx context.Context, txOption *sql.TxOptions, fn func(ctx context.Context) error) error {
 	fc := func(tx *gorm.DB) error {
-		ctx = context.WithValue(ctx, pkgContext.DBKey, tx)
+		ctx = context.WithValue(ctx, ctxkeys.DBKey, tx)
 
 		err := fn(ctx)
 		if err != nil {
@@ -157,7 +157,7 @@ func (db *DB) Transaction(ctx context.Context, txOption *sql.TxOptions, fn func(
 }
 
 func (db *DB) getDB(ctx context.Context) (*gorm.DB, error) {
-	iDB := ctx.Value(pkgContext.DBKey)
+	iDB := ctx.Value(ctxkeys.DBKey)
 	if iDB == nil {
 		return db.db.WithContext(ctx), nil
 	}


### PR DESCRIPTION
### **User description**
現在のmainブランチでは
```
     pkg/context/keys.go:1:9: var-naming: avoid package names that conflict with Go standard library package names (revive)
     package context
```
というエラーが出ている。これに対応するためにtraPCollectionでカスタム定義してる方のパッケージ名をリネームする。


___

### **PR Type**
Bug fix


___

### **Description**
- 非標準lib重複のパッケージ名を改名

- 参照箇所を新パッケージ名へ更新


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pkg/context/keys.go package名"] -- rename --> B["ctxkeys"]
  C["gorm2/db.go import"] -- update --> D["ctxkeys参照"]
  C -- context.WithValue --> E["ctxkeys.DBKey 使用"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>keys.go</strong><dd><code>パッケージ名をctxkeysへリネーム</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/context/keys.go

- パッケージ名を`context`から`ctxkeys`へ変更
- 他ファイルから参照されるキー定義の置き場を明確化


</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/1453/files#diff-bdc4e265b0df8d2a35a5781f06df0c2d32f92184af010c078c732aa0f05bd251">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>db.go</strong><dd><code>インポートとキー参照をctxkeysへ更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/repository/gorm2/db.go

<ul><li><code>pkg/context</code>のインポートを<code>ctxkeys</code>に合わせて更新<br> <li> <code>context.WithValue</code>でのキーを<code>ctxkeys.DBKey</code>に変更<br> <li> <code>ctx.Value</code>の取得キーを<code>ctxkeys.DBKey</code>に変更</ul>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/trap-collection-server/pull/1453/files#diff-437df3c61f3cc6927dd7954b21fb4e8ab3a9ef9fe2358fb6943af8a5b6a67f3e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

