### PR TITLE
:wrench: dockerのdependabotのgroup設定削除

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -39,13 +39,6 @@ updates:
           - 1.16.2.pre.alpine
     cooldown:
       default-days: 7
-    groups:
-      golang:
-        patterns:
-          - "golang"
-      atlas:
-        patterns:
-          - "arigaio/atlas*"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
group の設定を入れてから docker の dependabot が動かなくなってしまったので、設定を消してみる


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係の自動更新設定から、Golang および Atlas パッケージのグループ化ルールを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->