### PR TITLE
feat: リリース時にmanifestのrenovateを起動するように

### DIFF
--- a/.github/workflows/deploy-ci.yaml
+++ b/.github/workflows/deploy-ci.yaml
@@ -42,7 +42,6 @@ jobs:
     needs: [image]
     permissions:
       contents: read
-      actions: write
     steps:
       - name: Dispatch Renovate
         run: 'gh api --method POST -H "Accept: application/vnd.github+json" /repos/traPtitech/manifest/actions/workflows/renovate.yaml/dispatches -f "ref=main"'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,6 @@ jobs:
     needs: [image]
     permissions:
       contents: read
-      actions: write
     steps:
       - name: Dispatch Renovate
         run: 'gh api --method POST -H "Accept: application/vnd.github+json" /repos/traPtitech/manifest/actions/workflows/renovate.yaml/dispatches -f "ref=main"'


### PR DESCRIPTION
- k8sに移行したため、deploy-staging:の機能がいらなくなったため削除した
- mainにpushしたとき、リリースタグを打った時、にmanifestのRenovateを起動するようにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **チョア（Chores）**
  * ステージング環境へのSSH経由デプロイ処理を削除しました。
  * リリース／デプロイワークフローに、外部マニフェストリポジトリの依存更新（Renovate）を自動で起動するジョブを追加しました（イメージビルド完了後に実行）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->