### PR TITLE
traQの凍結済みユーザーも取得できるようにする

### DIFF
--- a/src/auth/traQ/user.go
+++ b/src/auth/traQ/user.go
@@ -221,3 +221,70 @@ func (u *User) GetActiveUsers(ctx context.Context, session *domain.OIDCSession) 
 
 	return users, nil
 }
+
+func (u *User) GetAllUsers(ctx context.Context, session *domain.OIDCSession) ([]*service.UserInfo, error) {
+	reqURL := *u.baseURL
+	var err error
+	reqURL.Path, err = url.JoinPath(reqURL.Path, "users")
+	if err != nil {
+		return nil, fmt.Errorf("join path: %w", err)
+	}
+
+	queryParams := reqURL.Query()
+	queryParams.Set("include-suspended", "true")
+	reqURL.RawQuery = queryParams.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", session.GetAccessToken()))
+
+	res, err := u.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+	case http.StatusUnauthorized:
+		return nil, auth.ErrInvalidSession
+	case http.StatusInternalServerError:
+		return nil, auth.ErrIdpBroken
+	default:
+		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	var response []*getUsersResponse
+	err = json.NewDecoder(res.Body).Decode(&response)
+	if err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	users := make([]*service.UserInfo, 0, len(response))
+	for _, user := range response {
+		var status values.TraPMemberStatus
+		switch user.State {
+		case 0:
+			status = values.TrapMemberStatusDeactivated
+		case 1:
+			status = values.TrapMemberStatusActive
+		case 2:
+			status = values.TrapMemberStatusSuspended
+		default:
+			return nil, fmt.Errorf("unexpected state: %d", user.State)
+		}
+		bot := user.Bot
+
+		users = append(users, service.NewUserInfo(
+			values.NewTrapMemberID(user.ID),
+			values.NewTrapMemberName(user.Name),
+			status,
+			bot,
+		))
+	}
+
+	return users, nil
+}

--- a/src/auth/traQ/user.go
+++ b/src/auth/traQ/user.go
@@ -276,13 +276,12 @@ func (u *User) GetAllUsers(ctx context.Context, session *domain.OIDCSession) ([]
 		default:
 			return nil, fmt.Errorf("unexpected state: %d", user.State)
 		}
-		bot := user.Bot
 
 		users = append(users, service.NewUserInfo(
 			values.NewTrapMemberID(user.ID),
 			values.NewTrapMemberName(user.Name),
 			status,
-			bot,
+			user.Bot,
 		))
 	}
 

--- a/src/auth/traQ/user_test.go
+++ b/src/auth/traQ/user_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/trap-collection-server/src/auth"
 	"github.com/traPtitech/trap-collection-server/src/config/mock"
 	"github.com/traPtitech/trap-collection-server/src/domain"
@@ -885,6 +886,158 @@ func TestGetActiveUsers(t *testing.T) {
 				assert.Equal(t, user.GetName(), users[i].GetName())
 				assert.Equal(t, user.GetStatus(), users[i].GetStatus())
 			}
+		})
+	}
+}
+
+func TestGetAllUsers(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	userName := "mazrean"
+
+	testCases := map[string]struct {
+		statusCode   int
+		traqResponse []*getUsersResponse
+		users        []*service.UserInfo
+		err          error
+	}{
+		"traQが500を返すので、ErrIdpBroken": {
+			statusCode: http.StatusInternalServerError,
+			err:        auth.ErrIdpBroken,
+		},
+		"traQが401を返すので、ErrInvalidSession": {
+			statusCode: http.StatusUnauthorized,
+			err:        auth.ErrInvalidSession,
+		},
+		"deactivatedユーザー": {
+			statusCode: http.StatusOK,
+			traqResponse: []*getUsersResponse{
+				{
+					ID:    userID,
+					Name:  userName,
+					State: 0,
+				},
+			},
+			users: []*service.UserInfo{
+				service.NewUserInfo(
+					values.NewTrapMemberID(userID),
+					values.NewTrapMemberName(userName),
+					values.TrapMemberStatusDeactivated,
+					false,
+				),
+			},
+		},
+		"activeユーザー": {
+			statusCode: http.StatusOK,
+			traqResponse: []*getUsersResponse{
+				{
+					ID:    userID,
+					Name:  userName,
+					State: 1,
+				},
+			},
+			users: []*service.UserInfo{
+				service.NewUserInfo(
+					values.NewTrapMemberID(userID),
+					values.NewTrapMemberName(userName),
+					values.TrapMemberStatusActive,
+					false,
+				),
+			},
+		},
+		"suspendedユーザー": {
+			statusCode: http.StatusOK,
+			traqResponse: []*getUsersResponse{
+				{
+					ID:    userID,
+					Name:  userName,
+					State: 2,
+				},
+			},
+			users: []*service.UserInfo{
+				service.NewUserInfo(
+					values.NewTrapMemberID(userID),
+					values.NewTrapMemberName(userName),
+					values.TrapMemberStatusSuspended,
+					false,
+				),
+			},
+		},
+		"botユーザー": {
+			statusCode: http.StatusOK,
+			traqResponse: []*getUsersResponse{
+				{
+					ID:    userID,
+					Name:  userName,
+					State: 1,
+					Bot:   true,
+				},
+			},
+			users: []*service.UserInfo{
+				service.NewUserInfo(
+					values.NewTrapMemberID(userID),
+					values.NewTrapMemberName(userName),
+					values.TrapMemberStatusActive,
+					true,
+				),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewUnstartedServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/users" {
+						w.WriteHeader(http.StatusNotFound)
+						return
+					}
+
+					if r.Method != http.MethodGet {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+
+					w.WriteHeader(testCase.statusCode)
+					body, err := json.Marshal(testCase.traqResponse)
+					require.NoError(t, err)
+					w.Header().Set("Content-Type", "application/json; charset=utf-8")
+					_, err = w.Write(body)
+					require.NoError(t, err)
+				},
+			))
+			ts.EnableHTTP2 = true
+			ts.StartTLS()
+			defer ts.Close()
+
+			baseURL, err := url.Parse(ts.URL)
+			require.NoError(t, err)
+
+			ctrl := gomock.NewController(t)
+
+			mockConfig := mock.NewMockAuthTraQ(ctrl)
+			mockConfig.
+				EXPECT().
+				HTTPClient().
+				Return(ts.Client(), nil)
+			mockConfig.
+				EXPECT().
+				BaseURL().
+				Return(baseURL, nil)
+			userAuth, err := NewUser(mockConfig)
+			require.NoError(t, err)
+
+			session := domain.NewOIDCSession(
+				values.NewOIDCAccessToken("accessToken"),
+				time.Now().Add(5*time.Second),
+			)
+
+			_, err = userAuth.GetAllUsers(t.Context(), session)
+
+			assert.ErrorIs(t, err, testCase.err)
 		})
 	}
 }

--- a/src/auth/traQ/user_test.go
+++ b/src/auth/traQ/user_test.go
@@ -1035,9 +1035,15 @@ func TestGetAllUsers(t *testing.T) {
 				time.Now().Add(5*time.Second),
 			)
 
-			_, err = userAuth.GetAllUsers(t.Context(), session)
+			users, err := userAuth.GetAllUsers(t.Context(), session)
 
 			assert.ErrorIs(t, err, testCase.err)
+
+			if testCase.err != nil {
+				return
+			}
+
+			assert.Equal(t, testCase.users, users)
 		})
 	}
 }

--- a/src/auth/traQ/user_test.go
+++ b/src/auth/traQ/user_test.go
@@ -1001,10 +1001,10 @@ func TestGetAllUsers(t *testing.T) {
 						return
 					}
 
-					w.WriteHeader(testCase.statusCode)
 					body, err := json.Marshal(testCase.traqResponse)
 					require.NoError(t, err)
 					w.Header().Set("Content-Type", "application/json; charset=utf-8")
+					w.WriteHeader(testCase.statusCode)
 					_, err = w.Write(body)
 					require.NoError(t, err)
 				},

--- a/src/auth/traQ/user_test.go
+++ b/src/auth/traQ/user_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1000,6 +1001,11 @@ func TestGetAllUsers(t *testing.T) {
 						w.WriteHeader(http.StatusMethodNotAllowed)
 						return
 					}
+
+					includeSuspendedStr := r.URL.Query().Get("include-suspended")
+					includeSuspended, err := strconv.ParseBool(includeSuspendedStr)
+					assert.NoError(t, err)
+					assert.True(t, includeSuspended)
 
 					body, err := json.Marshal(testCase.traqResponse)
 					require.NoError(t, err)

--- a/src/auth/user.go
+++ b/src/auth/user.go
@@ -18,4 +18,8 @@ type User interface {
 	// GetActiveUsers
 	// traQの全アクティブユーザー(凍結されていないユーザー)の取得。
 	GetActiveUsers(ctx context.Context, session *domain.OIDCSession) ([]*service.UserInfo, error)
+	// GetAllUsers
+	// traQの全ユーザー(アクティブなユーザーと非アクティブなユーザーを含む)の取得。
+	// セッションが無効な場合は、ErrInvalidSessionを返す。
+	GetAllUsers(ctx context.Context, session *domain.OIDCSession) ([]*service.UserInfo, error)
 }

--- a/src/cache/ristretto/seat.go
+++ b/src/cache/ristretto/seat.go
@@ -13,9 +13,15 @@ import (
 )
 
 type Seat struct {
-	activeSeats    *ristretto.Cache[string, []*domain.Seat]
+	activeSeats    *ristretto.Cache[seatCacheKey, []*domain.Seat]
 	activeSeatsTTL time.Duration
 }
+
+type seatCacheKey string
+
+const (
+	activeSeatsKey seatCacheKey = "active_seats"
+)
 
 func NewSeat(conf config.CacheRistretto) (*Seat, error) {
 	activeSeatsTTL, err := conf.ActiveSeatsTTL()
@@ -23,7 +29,7 @@ func NewSeat(conf config.CacheRistretto) (*Seat, error) {
 		return nil, fmt.Errorf("failed to get active seats ttl: %w", err)
 	}
 
-	activeSeats, err := ristretto.NewCache[string, []*domain.Seat](&ristretto.Config[string, []*domain.Seat]{
+	activeSeats, err := ristretto.NewCache[seatCacheKey, []*domain.Seat](&ristretto.Config[seatCacheKey, []*domain.Seat]{
 		NumCounters: 10,
 		MaxCost:     64,
 		BufferItems: 64,
@@ -39,7 +45,7 @@ func NewSeat(conf config.CacheRistretto) (*Seat, error) {
 }
 
 func (seat *Seat) GetActiveSeats(_ context.Context) ([]*domain.Seat, error) {
-	seats, ok := seat.activeSeats.Get(activeUsersKey)
+	seats, ok := seat.activeSeats.Get(activeSeatsKey)
 	if !ok {
 		hitCount.WithLabelValues("active_seats", "miss").Inc()
 		return nil, cache.ErrCacheMiss
@@ -52,7 +58,7 @@ func (seat *Seat) GetActiveSeats(_ context.Context) ([]*domain.Seat, error) {
 func (seat *Seat) SetActiveSeats(_ context.Context, seats []*domain.Seat) error {
 	// キャッシュ追加待ちのキューに入るだけで、すぐにはキャッシュが効かないのに注意
 	ok := seat.activeSeats.SetWithTTL(
-		activeUsersKey,
+		activeSeatsKey,
 		seats,
 		1,
 		seat.activeSeatsTTL,

--- a/src/cache/ristretto/user.go
+++ b/src/cache/ristretto/user.go
@@ -16,7 +16,7 @@ import (
 
 type User struct {
 	meCache        *ristretto.Cache[string, *service.UserInfo]
-	activeUsers    *ristretto.Cache[usersCacheKey, []*service.UserInfo]
+	users          *ristretto.Cache[usersCacheKey, []*service.UserInfo]
 	activeUsersTTL time.Duration
 }
 
@@ -50,7 +50,7 @@ func NewUser(conf config.CacheRistretto) (*User, error) {
 		return nil, fmt.Errorf("failed to create meCache: %v", err)
 	}
 
-	activeUsers, err := ristretto.NewCache[usersCacheKey, []*service.UserInfo](&ristretto.Config[usersCacheKey, []*service.UserInfo]{
+	users, err := ristretto.NewCache[usersCacheKey, []*service.UserInfo](&ristretto.Config[usersCacheKey, []*service.UserInfo]{
 		NumCounters: 10,
 		MaxCost:     64,
 		BufferItems: 64,
@@ -61,7 +61,7 @@ func NewUser(conf config.CacheRistretto) (*User, error) {
 
 	return &User{
 		meCache:        meCache,
-		activeUsers:    activeUsers,
+		users:          users,
 		activeUsersTTL: activeUsersTTL,
 	}, nil
 }
@@ -96,7 +96,7 @@ func (u *User) SetMe(_ context.Context, session *domain.OIDCSession, user *servi
 // GetAllActiveUsers
 // deprecated: v1 API廃止時に削除する
 func (u *User) GetAllActiveUsers(_ context.Context) ([]*service.UserInfo, error) {
-	users, ok := u.activeUsers.Get(activeUsersKey)
+	users, ok := u.users.Get(activeUsersKey)
 	if !ok {
 		hitCount.WithLabelValues("active_users", "miss").Inc()
 		return nil, cache.ErrCacheMiss
@@ -110,7 +110,7 @@ func (u *User) GetAllActiveUsers(_ context.Context) ([]*service.UserInfo, error)
 // deprecated: v1 API廃止時に削除する
 func (u *User) SetAllActiveUsers(_ context.Context, users []*service.UserInfo) error {
 	// キャッシュ追加待ちのキューに入るだけで、すぐにはキャッシュが効かないのに注意
-	ok := u.activeUsers.SetWithTTL(
+	ok := u.users.SetWithTTL(
 		activeUsersKey,
 		users,
 		1,
@@ -124,7 +124,7 @@ func (u *User) SetAllActiveUsers(_ context.Context, users []*service.UserInfo) e
 }
 
 func (u *User) GetActiveUsers(_ context.Context) ([]*service.UserInfo, error) {
-	users, ok := u.activeUsers.Get(activeUsersKey)
+	users, ok := u.users.Get(activeUsersKey)
 	if !ok {
 		return nil, cache.ErrCacheMiss
 	}
@@ -134,7 +134,7 @@ func (u *User) GetActiveUsers(_ context.Context) ([]*service.UserInfo, error) {
 
 func (u *User) SetActiveUsers(_ context.Context, users []*service.UserInfo) error {
 	// キャッシュ追加待ちのキューに入るだけで、すぐにはキャッシュが効かないのに注意
-	ok := u.activeUsers.SetWithTTL(
+	ok := u.users.SetWithTTL(
 		activeUsersKey,
 		users,
 		1,
@@ -148,7 +148,7 @@ func (u *User) SetActiveUsers(_ context.Context, users []*service.UserInfo) erro
 }
 
 func (u *User) GetAllUsers(_ context.Context) ([]*service.UserInfo, error) {
-	users, ok := u.activeUsers.Get(allUsersKey)
+	users, ok := u.users.Get(allUsersKey)
 	if !ok {
 		return nil, cache.ErrCacheMiss
 	}
@@ -158,7 +158,7 @@ func (u *User) GetAllUsers(_ context.Context) ([]*service.UserInfo, error) {
 
 func (u *User) SetAllUsers(_ context.Context, users []*service.UserInfo) error {
 	// キャッシュ追加待ちのキューに入るだけで、すぐにはキャッシュが効かないのに注意
-	ok := u.activeUsers.SetWithTTL(
+	ok := u.users.SetWithTTL(
 		allUsersKey,
 		users,
 		1,

--- a/src/cache/ristretto/user.go
+++ b/src/cache/ristretto/user.go
@@ -16,12 +16,15 @@ import (
 
 type User struct {
 	meCache        *ristretto.Cache[string, *service.UserInfo]
-	activeUsers    *ristretto.Cache[string, []*service.UserInfo]
+	activeUsers    *ristretto.Cache[usersCacheKey, []*service.UserInfo]
 	activeUsersTTL time.Duration
 }
 
+type usersCacheKey string
+
 const (
-	activeUsersKey = "active_users"
+	activeUsersKey usersCacheKey = "active_users"
+	allUsersKey    usersCacheKey = "all_users"
 )
 
 func NewUser(conf config.CacheRistretto) (*User, error) {
@@ -47,7 +50,7 @@ func NewUser(conf config.CacheRistretto) (*User, error) {
 		return nil, fmt.Errorf("failed to create meCache: %v", err)
 	}
 
-	activeUsers, err := ristretto.NewCache[string, []*service.UserInfo](&ristretto.Config[string, []*service.UserInfo]{
+	activeUsers, err := ristretto.NewCache[usersCacheKey, []*service.UserInfo](&ristretto.Config[usersCacheKey, []*service.UserInfo]{
 		NumCounters: 10,
 		MaxCost:     64,
 		BufferItems: 64,
@@ -139,6 +142,30 @@ func (u *User) SetActiveUsers(_ context.Context, users []*service.UserInfo) erro
 	)
 	if !ok {
 		return errors.New("failed to set activeUsers")
+	}
+
+	return nil
+}
+
+func (u *User) GetAllUsers(_ context.Context) ([]*service.UserInfo, error) {
+	users, ok := u.activeUsers.Get(allUsersKey)
+	if !ok {
+		return nil, cache.ErrCacheMiss
+	}
+
+	return users, nil
+}
+
+func (u *User) SetAllUsers(_ context.Context, users []*service.UserInfo) error {
+	// キャッシュ追加待ちのキューに入るだけで、すぐにはキャッシュが効かないのに注意
+	ok := u.activeUsers.SetWithTTL(
+		allUsersKey,
+		users,
+		1,
+		u.activeUsersTTL,
+	)
+	if !ok {
+		return errors.New("failed to set allUsers")
 	}
 
 	return nil

--- a/src/cache/ristretto/user.go
+++ b/src/cache/ristretto/user.go
@@ -126,8 +126,10 @@ func (u *User) SetAllActiveUsers(_ context.Context, users []*service.UserInfo) e
 func (u *User) GetActiveUsers(_ context.Context) ([]*service.UserInfo, error) {
 	users, ok := u.users.Get(activeUsersKey)
 	if !ok {
+		hitCount.WithLabelValues("active_users", "miss").Inc()
 		return nil, cache.ErrCacheMiss
 	}
+	hitCount.WithLabelValues("active_users", "hit").Inc()
 
 	return users, nil
 }
@@ -150,8 +152,10 @@ func (u *User) SetActiveUsers(_ context.Context, users []*service.UserInfo) erro
 func (u *User) GetAllUsers(_ context.Context) ([]*service.UserInfo, error) {
 	users, ok := u.users.Get(allUsersKey)
 	if !ok {
+		hitCount.WithLabelValues("all_users", "miss").Inc()
 		return nil, cache.ErrCacheMiss
 	}
+	hitCount.WithLabelValues("all_users", "hit").Inc()
 
 	return users, nil
 }

--- a/src/cache/ristretto/user_test.go
+++ b/src/cache/ristretto/user_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/trap-collection-server/src/cache"
 	"github.com/traPtitech/trap-collection-server/src/config/mock"
 	"github.com/traPtitech/trap-collection-server/src/domain"
@@ -249,11 +251,11 @@ func TestGetAllActiveUsers(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
 			if testCase.keyExist {
-				ok := userCache.activeUsers.Set(activeUsersKey, testCase.users, 8)
+				ok := userCache.users.Set(activeUsersKey, testCase.users, 8)
 				assert.True(t, ok)
 
-				userCache.activeUsers.Wait()
-				defer userCache.activeUsers.Clear()
+				userCache.users.Wait()
+				defer userCache.users.Clear()
 			}
 
 			users, err := userCache.GetAllActiveUsers(ctx)
@@ -343,10 +345,10 @@ func TestSetAllActiveUsers(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
 			if testCase.keyExist {
-				ok := userCache.activeUsers.Set(activeUsersKey, testCase.beforeValue, 1)
+				ok := userCache.users.Set(activeUsersKey, testCase.beforeValue, 1)
 				assert.True(t, ok)
 
-				userCache.activeUsers.Wait()
+				userCache.users.Wait()
 			}
 
 			err := userCache.SetAllActiveUsers(ctx, testCase.users)
@@ -365,10 +367,10 @@ func TestSetAllActiveUsers(t *testing.T) {
 			}
 
 			// キャッシュが設定されるまで待機
-			userCache.activeUsers.Wait()
+			userCache.users.Wait()
 
 			// OIDCSessionの期限前なのでキャッシュされている
-			actualUsers, ok := userCache.activeUsers.Get(activeUsersKey)
+			actualUsers, ok := userCache.users.Get(activeUsersKey)
 			assert.True(t, ok)
 
 			for i, user := range testCase.users {
@@ -436,11 +438,11 @@ func TestGetActiveUsers(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
 			if testCase.keyExist {
-				ok := userCache.activeUsers.Set(activeUsersKey, testCase.users, 8)
+				ok := userCache.users.Set(activeUsersKey, testCase.users, 8)
 				assert.True(t, ok)
 
-				userCache.activeUsers.Wait()
-				defer userCache.activeUsers.Clear()
+				userCache.users.Wait()
+				defer userCache.users.Clear()
 			}
 
 			users, err := userCache.GetActiveUsers(ctx)
@@ -530,10 +532,10 @@ func TestSetActiveUsers(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
 			if testCase.keyExist {
-				ok := userCache.activeUsers.Set(activeUsersKey, testCase.beforeValue, 1)
+				ok := userCache.users.Set(activeUsersKey, testCase.beforeValue, 1)
 				assert.True(t, ok)
 
-				userCache.activeUsers.Wait()
+				userCache.users.Wait()
 			}
 
 			err := userCache.SetActiveUsers(ctx, testCase.users)
@@ -552,10 +554,10 @@ func TestSetActiveUsers(t *testing.T) {
 			}
 
 			// キャッシュが設定されるまで待機
-			userCache.activeUsers.Wait()
+			userCache.users.Wait()
 
 			// OIDCSessionの期限前なのでキャッシュされている
-			actualUsers, ok := userCache.activeUsers.Get(activeUsersKey)
+			actualUsers, ok := userCache.users.Get(activeUsersKey)
 			assert.True(t, ok)
 
 			for i, user := range testCase.users {
@@ -565,6 +567,80 @@ func TestSetActiveUsers(t *testing.T) {
 					assert.Equal(t, *actualUsers[i], *user)
 				}
 			}
+		})
+	}
+}
+
+func TestGetAllUsers(t *testing.T) {
+	t.Parallel()
+
+	user1 := service.NewUserInfo(
+		values.NewTrapMemberID(uuid.New()),
+		values.NewTrapMemberName("mazrean"),
+		values.TrapMemberStatusDeactivated,
+		false,
+	)
+	user2 := service.NewUserInfo(
+		values.NewTrapMemberID(uuid.New()),
+		values.NewTrapMemberName("ikura-hamu"),
+		values.TrapMemberStatusActive,
+		false,
+	)
+
+	ttl := time.Hour
+	testCases := map[string]struct {
+		users []*service.UserInfo
+		after time.Duration
+		err   error
+	}{
+		"ttl前なのでキャッシュされている": {
+			users: []*service.UserInfo{user1, user2},
+			after: time.Second,
+		},
+		"ttl後なのでキャッシュされていない": {
+			users: []*service.UserInfo{user1, user2},
+			after: ttl + time.Second,
+			err:   cache.ErrCacheMiss,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+				ctrl := gomock.NewController(t)
+				mockConf := mock.NewMockCacheRistretto(ctrl)
+
+				mockConf.
+					EXPECT().
+					ActiveUsersTTL().
+					Return(ttl, nil)
+
+				usersCache, err := NewUser(mockConf)
+				require.NoError(t, err)
+
+				t.Cleanup(func() {
+					usersCache.users.Close()
+					usersCache.meCache.Close()
+				})
+
+				if len(testCase.users) > 0 {
+					ok := usersCache.users.SetWithTTL(allUsersKey, testCase.users, 1, ttl)
+					require.True(t, ok)
+				}
+
+				time.Sleep(testCase.after)
+
+				users, err := usersCache.GetAllUsers(ctx)
+
+				if testCase.err != nil {
+					require.ErrorIs(t, err, testCase.err)
+				} else {
+					require.NoError(t, err)
+					assert.Equal(t, testCase.users, users)
+				}
+			})
 		})
 	}
 }

--- a/src/cache/ristretto/user_test.go
+++ b/src/cache/ristretto/user_test.go
@@ -644,3 +644,86 @@ func TestGetAllUsers(t *testing.T) {
 		})
 	}
 }
+
+func TestSetAllUsers(t *testing.T) {
+	t.Parallel()
+
+	ttl := time.Hour
+
+	user1 := service.NewUserInfo(
+		values.NewTrapMemberID(uuid.New()),
+		values.NewTrapMemberName("mazrean"),
+		values.TrapMemberStatusDeactivated,
+		false,
+	)
+	user2 := service.NewUserInfo(
+		values.NewTrapMemberID(uuid.New()),
+		values.NewTrapMemberName("ikura-hamu"),
+		values.TrapMemberStatusActive,
+		false,
+	)
+
+	testCases := map[string]struct {
+		beforeUsers []*service.UserInfo
+		users       []*service.UserInfo
+		err         error
+	}{
+		"ユーザー情報をセットできる": {
+			users: []*service.UserInfo{user1, user2},
+		},
+		"元からキーがあっても上書きする": {
+			beforeUsers: []*service.UserInfo{user1},
+			users:       []*service.UserInfo{user2},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+				ctrl := gomock.NewController(t)
+				mockConf := mock.NewMockCacheRistretto(ctrl)
+
+				mockConf.
+					EXPECT().
+					ActiveUsersTTL().
+					Return(ttl, nil)
+
+				usersCache, err := NewUser(mockConf)
+				require.NoError(t, err)
+
+				t.Cleanup(func() {
+					usersCache.users.Close()
+					usersCache.meCache.Close()
+				})
+
+				if len(testCase.beforeUsers) > 0 {
+					ok := usersCache.users.SetWithTTL(allUsersKey, testCase.beforeUsers, 1, ttl)
+					require.True(t, ok)
+					usersCache.users.Wait()
+				}
+
+				err = usersCache.SetAllUsers(ctx, testCase.users)
+				if testCase.err != nil {
+					assert.ErrorIs(t, err, testCase.err)
+				}
+				assert.NoError(t, err)
+
+				usersCache.users.Wait()
+
+				users, ok := usersCache.users.Get(allUsersKey)
+				assert.True(t, ok)
+				assert.Equal(t, testCase.users, users)
+
+				time.Sleep(ttl + time.Second)
+
+				_, ok = usersCache.users.Get(allUsersKey)
+				assert.False(t, ok)
+			})
+
+		})
+	}
+
+}

--- a/src/cache/ristretto/user_test.go
+++ b/src/cache/ristretto/user_test.go
@@ -625,13 +625,13 @@ func TestGetAllUsers(t *testing.T) {
 					usersCache.meCache.Close()
 				})
 
-			if len(testCase.users) > 0 {
-				ok := usersCache.users.SetWithTTL(allUsersKey, testCase.users, 1, ttl)
-				require.True(t, ok)
-				usersCache.users.Wait()
-			}
+				if len(testCase.users) > 0 {
+					ok := usersCache.users.SetWithTTL(allUsersKey, testCase.users, 1, ttl)
+					require.True(t, ok)
+					usersCache.users.Wait()
+				}
 
-			time.Sleep(testCase.after)
+				time.Sleep(testCase.after)
 
 				users, err := usersCache.GetAllUsers(ctx)
 
@@ -709,6 +709,7 @@ func TestSetAllUsers(t *testing.T) {
 				err = usersCache.SetAllUsers(ctx, testCase.users)
 				if testCase.err != nil {
 					assert.ErrorIs(t, err, testCase.err)
+					return
 				}
 				assert.NoError(t, err)
 

--- a/src/cache/ristretto/user_test.go
+++ b/src/cache/ristretto/user_test.go
@@ -625,12 +625,13 @@ func TestGetAllUsers(t *testing.T) {
 					usersCache.meCache.Close()
 				})
 
-				if len(testCase.users) > 0 {
-					ok := usersCache.users.SetWithTTL(allUsersKey, testCase.users, 1, ttl)
-					require.True(t, ok)
-				}
+			if len(testCase.users) > 0 {
+				ok := usersCache.users.SetWithTTL(allUsersKey, testCase.users, 1, ttl)
+				require.True(t, ok)
+				usersCache.users.Wait()
+			}
 
-				time.Sleep(testCase.after)
+			time.Sleep(testCase.after)
 
 				users, err := usersCache.GetAllUsers(ctx)
 

--- a/src/cache/user.go
+++ b/src/cache/user.go
@@ -31,4 +31,12 @@ type User interface {
 	// SetActiveUsers
 	// traQの全アクティブユーザー(凍結されていないユーザー)のキャッシュ設定。
 	SetActiveUsers(ctx context.Context, users []*service.UserInfo) error
+	// GetAllUsers
+	// traQの全ユーザー(アクティブなユーザーと非アクティブなユーザーを含む)のキャッシュ取得。
+	// キャッシュ設定から1時間の間有効。
+	// このため、traQでのユーザーの状態変更の反映までに最大1時間の遅延が発生する点に注意。
+	GetAllUsers(ctx context.Context) ([]*service.UserInfo, error)
+	// SetAllUsers
+	// traQの全ユーザー(アクティブなユーザーと非アクティブなユーザーを含む)のキャッシュ設定。
+	SetAllUsers(ctx context.Context, users []*service.UserInfo) error
 }

--- a/src/service/v2/game_creator.go
+++ b/src/service/v2/game_creator.go
@@ -127,8 +127,7 @@ func (gc *GameCreator) validateEditGameCreatorsInput(
 	presetJobsMap map[values.GameCreatorJobID]*domain.GameCreatorJob,
 	inputs []*service.EditGameCreatorJobInput,
 ) (*editGameCreatorsValidatedInput, error) {
-	// TODO: 今の実装は現役しか取得できないので、凍結済みユーザーを取得できるようにする
-	activeMembers, err := gc.user.getActiveUsers(ctx, session)
+	activeMembers, err := gc.user.getAllUsers(ctx, session)
 	if err != nil {
 		return nil, fmt.Errorf("get active users: %w", err)
 	}

--- a/src/service/v2/game_creator.go
+++ b/src/service/v2/game_creator.go
@@ -129,7 +129,7 @@ func (gc *GameCreator) validateEditGameCreatorsInput(
 ) (*editGameCreatorsValidatedInput, error) {
 	activeMembers, err := gc.user.getAllUsers(ctx, session)
 	if err != nil {
-		return nil, fmt.Errorf("get active users: %w", err)
+		return nil, fmt.Errorf("get all users: %w", err)
 	}
 
 	activeMembersMap := make(map[values.TraPMemberID]*service.UserInfo, len(activeMembers))

--- a/src/service/v2/game_creator_test.go
+++ b/src/service/v2/game_creator_test.go
@@ -248,11 +248,11 @@ func TestEditGameCreators(t *testing.T) {
 		executeGetGameCreatorPresetJobs     bool
 		presetJobs                          []*domain.GameCreatorJob
 		getGameCreatorPresetJobsErr         error
-		executeGetActiveUsers               bool
+		executeGetAllUsers                  bool
 		cacheUsers                          []*service.UserInfo
-		cacheGetActiveUsersErr              error
+		cacheGetAllUsersErr                 error
 		authUsers                           []*service.UserInfo
-		authGetActiveUsersErr               error
+		authGetAllUsersErr                  error
 		executeGetGameCreatorCustomJobsByID bool
 		existingCustomJobs                  []*domain.GameCreatorCustomJob
 		getGameCreatorCustomJobsByIDErr     error
@@ -288,23 +288,23 @@ func TestEditGameCreators(t *testing.T) {
 			getGameCreatorPresetJobsErr:     assert.AnError,
 			wantErr:                         assert.AnError,
 		},
-		"active user取得でエラーなのでエラー": {
+		"all user取得でエラーなのでエラー": {
 			gameID:                          gameID,
 			inputs:                          []*service.EditGameCreatorJobInput{{UserID: user1.GetID()}},
 			executeGetGameCreatorPresetJobs: true,
 			presetJobs:                      []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:           true,
-			cacheGetActiveUsersErr:          cache.ErrCacheMiss,
-			authGetActiveUsersErr:           assert.AnError,
+			executeGetAllUsers:              true,
+			cacheGetAllUsersErr:             cache.ErrCacheMiss,
+			authGetAllUsersErr:              assert.AnError,
 			wantErr:                         assert.AnError,
 		},
-		"active usersに存在しないユーザーが入力された場合ErrInvalidUserID": {
+		"all usersに存在しないユーザーが入力された場合ErrInvalidUserID": {
 			gameID:                          gameID,
 			inputs:                          []*service.EditGameCreatorJobInput{{UserID: invalidUserID}},
 			executeGetGameCreatorPresetJobs: true,
 			presetJobs:                      []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:           true,
-			cacheGetActiveUsersErr:          cache.ErrCacheMiss,
+			executeGetAllUsers:              true,
+			cacheGetAllUsersErr:             cache.ErrCacheMiss,
 			authUsers:                       []*service.UserInfo{user1, user2},
 			wantErr:                         service.ErrInvalidUserID,
 		},
@@ -313,8 +313,8 @@ func TestEditGameCreators(t *testing.T) {
 			inputs:                          []*service.EditGameCreatorJobInput{{UserID: user1.GetID()}, {UserID: user1.GetID()}},
 			executeGetGameCreatorPresetJobs: true,
 			presetJobs:                      []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:           true,
-			cacheGetActiveUsersErr:          cache.ErrCacheMiss,
+			executeGetAllUsers:              true,
+			cacheGetAllUsersErr:             cache.ErrCacheMiss,
 			authUsers:                       []*service.UserInfo{user1, user2},
 			wantErr:                         service.ErrDuplicateUserID,
 		},
@@ -323,8 +323,8 @@ func TestEditGameCreators(t *testing.T) {
 			inputs:                              []*service.EditGameCreatorJobInput{{UserID: user1.GetID(), NewCustomJobNames: []values.GameCreatorJobDisplayName{existingCustomJob.GetDisplayName()}}},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:               true,
-			cacheGetActiveUsersErr:              cache.ErrCacheMiss,
+			executeGetAllUsers:                  true,
+			cacheGetAllUsersErr:                 cache.ErrCacheMiss,
 			authUsers:                           []*service.UserInfo{user1, user2},
 			executeGetGameCreatorCustomJobsByID: true,
 			existingCustomJobs:                  []*domain.GameCreatorCustomJob{existingCustomJob},
@@ -335,8 +335,8 @@ func TestEditGameCreators(t *testing.T) {
 			inputs:                              []*service.EditGameCreatorJobInput{{UserID: user1.GetID(), Jobs: []values.GameCreatorJobID{values.NewGameCreatorJobID()}}},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:               true,
-			cacheGetActiveUsersErr:              cache.ErrCacheMiss,
+			executeGetAllUsers:                  true,
+			cacheGetAllUsersErr:                 cache.ErrCacheMiss,
 			authUsers:                           []*service.UserInfo{user1, user2},
 			executeGetGameCreatorCustomJobsByID: true,
 			existingCustomJobs:                  []*domain.GameCreatorCustomJob{existingCustomJob},
@@ -350,8 +350,8 @@ func TestEditGameCreators(t *testing.T) {
 			}},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:               true,
-			cacheGetActiveUsersErr:              cache.ErrCacheMiss,
+			executeGetAllUsers:                  true,
+			cacheGetAllUsersErr:                 cache.ErrCacheMiss,
 			authUsers:                           []*service.UserInfo{user1, user2},
 			executeGetGameCreatorCustomJobsByID: true,
 			existingCustomJobs:                  []*domain.GameCreatorCustomJob{},
@@ -362,8 +362,8 @@ func TestEditGameCreators(t *testing.T) {
 			inputs:                              []*service.EditGameCreatorJobInput{{UserID: user1.GetID()}},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:               true,
-			cacheGetActiveUsersErr:              cache.ErrCacheMiss,
+			executeGetAllUsers:                  true,
+			cacheGetAllUsersErr:                 cache.ErrCacheMiss,
 			authUsers:                           []*service.UserInfo{user1},
 			executeGetGameCreatorCustomJobsByID: true,
 			getGameCreatorCustomJobsByIDErr:     assert.AnError,
@@ -374,8 +374,8 @@ func TestEditGameCreators(t *testing.T) {
 			inputs:                              []*service.EditGameCreatorJobInput{{UserID: user1.GetID()}},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:               true,
-			cacheGetActiveUsersErr:              cache.ErrCacheMiss,
+			executeGetAllUsers:                  true,
+			cacheGetAllUsersErr:                 cache.ErrCacheMiss,
 			authUsers:                           []*service.UserInfo{user1},
 			executeGetGameCreatorCustomJobsByID: true,
 			existingCustomJobs:                  []*domain.GameCreatorCustomJob{},
@@ -391,8 +391,8 @@ func TestEditGameCreators(t *testing.T) {
 			}},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:               true,
-			cacheGetActiveUsersErr:              cache.ErrCacheMiss,
+			executeGetAllUsers:                  true,
+			cacheGetAllUsersErr:                 cache.ErrCacheMiss,
 			authUsers:                           []*service.UserInfo{user1},
 			executeGetGameCreatorCustomJobsByID: true,
 			existingCustomJobs:                  []*domain.GameCreatorCustomJob{},
@@ -410,8 +410,8 @@ func TestEditGameCreators(t *testing.T) {
 			}},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			cacheGetActiveUsersErr:              cache.ErrCacheMiss,
-			executeGetActiveUsers:               true,
+			cacheGetAllUsersErr:                 cache.ErrCacheMiss,
+			executeGetAllUsers:                  true,
 			authUsers:                           []*service.UserInfo{user1},
 			executeGetGameCreatorCustomJobsByID: true,
 			existingCustomJobs:                  []*domain.GameCreatorCustomJob{},
@@ -430,8 +430,8 @@ func TestEditGameCreators(t *testing.T) {
 			}},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:               true,
-			cacheGetActiveUsersErr:              cache.ErrCacheMiss,
+			executeGetAllUsers:                  true,
+			cacheGetAllUsersErr:                 cache.ErrCacheMiss,
 			authUsers:                           []*service.UserInfo{user1},
 			executeGetGameCreatorCustomJobsByID: true,
 			existingCustomJobs:                  []*domain.GameCreatorCustomJob{existingCustomJob},
@@ -452,8 +452,8 @@ func TestEditGameCreators(t *testing.T) {
 			}},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:               true,
-			cacheGetActiveUsersErr:              cache.ErrCacheMiss,
+			executeGetAllUsers:                  true,
+			cacheGetAllUsersErr:                 cache.ErrCacheMiss,
 			authUsers:                           []*service.UserInfo{user1},
 			executeGetGameCreatorCustomJobsByID: true,
 			existingCustomJobs:                  []*domain.GameCreatorCustomJob{existingCustomJob},
@@ -482,7 +482,7 @@ func TestEditGameCreators(t *testing.T) {
 			},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:               true,
+			executeGetAllUsers:                  true,
 			cacheUsers:                          []*service.UserInfo{user1, user2},
 			executeGetGameCreatorCustomJobsByID: true,
 			existingCustomJobs:                  []*domain.GameCreatorCustomJob{existingCustomJob},
@@ -503,8 +503,8 @@ func TestEditGameCreators(t *testing.T) {
 			}},
 			executeGetGameCreatorPresetJobs:     true,
 			presetJobs:                          []*domain.GameCreatorJob{presetJob1, presetJob2},
-			executeGetActiveUsers:               true,
-			cacheGetActiveUsersErr:              cache.ErrCacheMiss,
+			executeGetAllUsers:                  true,
+			cacheGetAllUsersErr:                 cache.ErrCacheMiss,
 			authUsers:                           []*service.UserInfo{user1},
 			executeGetGameCreatorCustomJobsByID: true,
 			existingCustomJobs:                  []*domain.GameCreatorCustomJob{existingCustomJob},
@@ -538,25 +538,25 @@ func TestEditGameCreators(t *testing.T) {
 				GetGame(gomock.Any(), testCase.gameID, repository.LockTypeNone).
 				Return(nil, testCase.getGameErr)
 
-			if testCase.executeGetActiveUsers {
+			if testCase.executeGetAllUsers {
 				cacheUsers := testCase.cacheUsers
 				if cacheUsers == nil {
 					cacheUsers = []*service.UserInfo{}
 				}
 				mockUserCache.EXPECT().
-					GetActiveUsers(gomock.Any()).
-					Return(cacheUsers, testCase.cacheGetActiveUsersErr)
-				if testCase.cacheGetActiveUsersErr != nil {
+					GetAllUsers(gomock.Any()).
+					Return(cacheUsers, testCase.cacheGetAllUsersErr)
+				if testCase.cacheGetAllUsersErr != nil {
 					authUsers := testCase.authUsers
 					if authUsers == nil {
 						authUsers = []*service.UserInfo{}
 					}
 					mockUserAuth.EXPECT().
-						GetActiveUsers(gomock.Any(), sess).
-						Return(authUsers, testCase.authGetActiveUsersErr)
-					if testCase.authGetActiveUsersErr == nil {
+						GetAllUsers(gomock.Any(), sess).
+						Return(authUsers, testCase.authGetAllUsersErr)
+					if testCase.authGetAllUsersErr == nil {
 						mockUserCache.EXPECT().
-							SetActiveUsers(gomock.Any(), authUsers).
+							SetAllUsers(gomock.Any(), authUsers).
 							Return(nil)
 					}
 				}

--- a/src/service/v2/oidc.go
+++ b/src/service/v2/oidc.go
@@ -171,3 +171,28 @@ func (uu *User) getActiveUsers(ctx context.Context, session *domain.OIDCSession)
 
 	return users, nil
 }
+
+func (uu *User) getAllUsers(ctx context.Context, session *domain.OIDCSession) ([]*service.UserInfo, error) {
+	users, err := uu.userCache.GetAllUsers(ctx)
+	if err != nil && !errors.Is(err, cache.ErrCacheMiss) {
+		// cacheからの取り出しに失敗してもauthからとって来れれば良いので、returnはしない
+		log.Printf("failed to get users from cache: %v\n", err)
+	}
+	// cacheから取り出した場合はそれを返す
+	if err == nil {
+		return users, nil
+	}
+
+	users, err = uu.userAuth.GetAllUsers(ctx, session)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user info: %w", err)
+	}
+
+	err = uu.userCache.SetAllUsers(ctx, users)
+	if err != nil {
+		// cacheの設定に失敗してもreturnはしない
+		log.Printf("error: failed to set user info: %v\n", err)
+	}
+
+	return users, nil
+}

--- a/src/service/v2/oidc_test.go
+++ b/src/service/v2/oidc_test.go
@@ -555,3 +555,108 @@ func TestGetActiveUsers(t *testing.T) {
 		})
 	}
 }
+
+func Test_getAllUsers(t *testing.T) {
+	t.Parallel()
+
+	user1 := service.NewUserInfo(
+		values.NewTrapMemberID(uuid.New()),
+		values.NewTrapMemberName("mazrean"),
+		values.TrapMemberStatusActive,
+		false,
+	)
+	user2 := service.NewUserInfo(
+		values.NewTrapMemberID(uuid.New()),
+		values.NewTrapMemberName("ikura-hamu"),
+		values.TrapMemberStatusActive,
+		false,
+	)
+
+	testCases := map[string]struct {
+		GetAllUsersCacheErr     error
+		GetAllUsersCacheUsers   []*service.UserInfo
+		executeAuthGetAllUsers  bool
+		GetAllUsersAuthErr      error
+		GetAllUsersAuthUsers    []*service.UserInfo
+		executeSetAllUsersCache bool
+		SetAllUsersCacheErr     error
+		users                   []*service.UserInfo
+		err                     error
+	}{
+		"cacheのGetAllUsersがusersを返す": {
+			GetAllUsersCacheUsers: []*service.UserInfo{user1, user2},
+			users:                 []*service.UserInfo{user1, user2},
+		},
+		"authのGetAllUsersがエラーなのでエラー": {
+			GetAllUsersCacheErr:    cache.ErrCacheMiss,
+			executeAuthGetAllUsers: true,
+			GetAllUsersAuthErr:     assert.AnError,
+			err:                    assert.AnError,
+			users:                  nil,
+		},
+		"cacheのGetAllUsersがキャッシュミスだがauthのGetAllUsersがusersを返す": {
+			GetAllUsersCacheErr:     cache.ErrCacheMiss,
+			executeAuthGetAllUsers:  true,
+			GetAllUsersAuthUsers:    []*service.UserInfo{user1, user2},
+			executeSetAllUsersCache: true,
+			SetAllUsersCacheErr:     nil,
+			users:                   []*service.UserInfo{user1, user2},
+		},
+		"cacheのGetAllUsersがエラーだがauthのGetAllUsersがusersを返す": {
+			GetAllUsersCacheErr:     assert.AnError,
+			executeAuthGetAllUsers:  true,
+			GetAllUsersAuthUsers:    []*service.UserInfo{user1, user2},
+			executeSetAllUsersCache: true,
+			SetAllUsersCacheErr:     nil,
+			users:                   []*service.UserInfo{user1, user2},
+		},
+		"SetAllUsersCacheがエラーでもユーザー情報は返す": {
+			GetAllUsersCacheErr:     cache.ErrCacheMiss,
+			executeAuthGetAllUsers:  true,
+			GetAllUsersAuthUsers:    []*service.UserInfo{user1, user2},
+			executeSetAllUsersCache: true,
+			SetAllUsersCacheErr:     assert.AnError,
+			users:                   []*service.UserInfo{user1, user2},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+
+			mockUserCache := mockCache.NewMockUser(ctrl)
+			mockUserAuth := mockAuth.NewMockUser(ctrl)
+			user := NewUser(mockUserAuth, mockUserCache)
+
+			session := &domain.OIDCSession{}
+
+			mockUserCache.EXPECT().GetAllUsers(gomock.Any()).
+				Return(testCase.GetAllUsersCacheUsers, testCase.GetAllUsersCacheErr)
+			if testCase.executeAuthGetAllUsers {
+				mockUserAuth.EXPECT().GetAllUsers(gomock.Any(), gomock.Any()).
+					Return(testCase.GetAllUsersAuthUsers, testCase.GetAllUsersAuthErr)
+			}
+			if testCase.executeSetAllUsersCache {
+				mockUserCache.EXPECT().SetAllUsers(gomock.Any(), testCase.GetAllUsersAuthUsers).
+					Return(testCase.SetAllUsersCacheErr)
+			}
+
+			users, err := user.getAllUsers(t.Context(), session)
+
+			if testCase.err != nil {
+				assert.ErrorIs(t, err, testCase.err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, testCase.users, users)
+		})
+	}
+
+}


### PR DESCRIPTION
fix #1529

- **:sparkles: traQの凍結済みユーザーも取得できるようにする**
- **:white_check_mark: GetAllUsersのテストを追加**
- **:sparkles: Userのキャッシュ実装**
- **:adhesive_bandage: seatでなぜかuserのキャッシュと同じキーが使われていたので修正**
- **:adhesive_bandage: userのフィールド名修正**
- **:white_check_mark: GetAllUsersのテスト**
- **:white_check_mark: SetAllUsersのテストを追加**
- **:sparkles: OIDCのサービスでgetAllUsersを実装**
- **:white_check_mark: getAllUsersのテスト**
- **:adhesive_bandage: creator側でactive usersを取っていたところをall usersに変更**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 全ユーザー（無効化・停止含む）取得とキャッシュの追加により、より広範なユーザー一覧が取得可能になりました。
  * ユーザー取得時の状態（有効/無効/停止）を反映するようになりました。

* **Bug Fixes / Improvements**
  * 外部認証のエラー応答を正しく扱うようになり、安定性が向上しました。
  * 入力検証が全ユーザーを参照するように更新され、妥当性チェックが改善されました。

* **Tests**
  * 全ユーザー取得とキャッシュの挙動を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->