### PR TITLE
repositoryのGetGameCreatorsByGameID

### DIFF
--- a/src/repository/gorm2/game_creator.go
+++ b/src/repository/gorm2/game_creator.go
@@ -189,7 +189,7 @@ func (gc *GameCreator) GetGameCreatorsByUserIDs(ctx context.Context, gameID valu
 	var gameCreators []schema.GameCreatorTable
 	err = db.Where("game_id = ?", uuid.UUID(gameID)).
 		Where("user_id IN ?", userUUIDs).
-		Order("created_at DESC").
+		Order("created_at ASC").
 		Find(&gameCreators).Error
 	if err != nil {
 		return nil, fmt.Errorf("find game creators: %w", err)

--- a/src/repository/gorm2/game_creator.go
+++ b/src/repository/gorm2/game_creator.go
@@ -175,6 +175,36 @@ func (gc *GameCreator) UpsertGameCreatorCustomJobsRelations(_ context.Context, _
 	return nil // TODO: implement
 }
 
-func (gc *GameCreator) GetGameCreatorsByUserIDs(_ context.Context, _ values.GameID, _ []values.TraPMemberID) ([]*domain.GameCreator, error) {
-	return nil, nil // TODO: implement
+func (gc *GameCreator) GetGameCreatorsByUserIDs(ctx context.Context, gameID values.GameID, userIDs []values.TraPMemberID) ([]*domain.GameCreator, error) {
+	db, err := gc.db.getDB(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get db: %w", err)
+	}
+
+	userUUIDs := make([]uuid.UUID, 0, len(userIDs))
+	for _, userID := range userIDs {
+		userUUIDs = append(userUUIDs, uuid.UUID(userID))
+	}
+
+	var gameCreators []schema.GameCreatorTable
+	err = db.Where("game_id = ?", uuid.UUID(gameID)).
+		Where("user_id IN ?", userUUIDs).
+		Order("created_at DESC").
+		Find(&gameCreators).Error
+	if err != nil {
+		return nil, fmt.Errorf("find game creators: %w", err)
+	}
+
+	gameCreatorsResult := make([]*domain.GameCreator, 0, len(gameCreators))
+	for _, gc := range gameCreators {
+		gameCreatorsResult = append(gameCreatorsResult, domain.NewGameCreator(
+			values.GameCreatorID(gc.ID),
+			values.TraPMemberID(gc.UserID),
+			values.GameID(gc.GameID),
+			values.TraPMemberName(gc.UserName),
+			gc.CreatedAt,
+		))
+	}
+
+	return gameCreatorsResult, nil
 }

--- a/src/repository/gorm2/game_creator_test.go
+++ b/src/repository/gorm2/game_creator_test.go
@@ -702,6 +702,17 @@ func TestGetGameCreatorsByUserIDs(t *testing.T) {
 		values.NewTrapMemberName(creatorSchema2.UserName),
 		creatorSchema2.CreatedAt,
 	)
+	creatorSchema3 := &schema.GameCreatorTable{
+		ID:        uuid.New(),
+		UserID:    creatorSchema1.UserID,
+		UserName:  "user3",
+		CreatedAt: time.Now().Add(-time.Hour),
+		Game: schema.GameTable2{
+			ID:               uuid.New(),
+			Name:             "game2",
+			VisibilityTypeID: 1,
+		},
+	}
 
 	testCases := map[string]struct {
 		creators []*schema.GameCreatorTable
@@ -726,6 +737,12 @@ func TestGetGameCreatorsByUserIDs(t *testing.T) {
 			gameID:   values.NewGameID(),
 			userIDs:  []values.TraPMemberID{values.NewTrapMemberID(uuid.New())},
 			result:   []*domain.GameCreator{},
+		},
+		"同じuserが複数gameにcreatorとして存在しても指定したgameの分だけcreatorが取得できる": {
+			creators: []*schema.GameCreatorTable{creatorSchema1, creatorSchema3},
+			gameID:   values.NewGameIDFromUUID(creatorSchema1.Game.ID),
+			userIDs:  []values.TraPMemberID{creator1.GetUserID()},
+			result:   []*domain.GameCreator{creator1},
 		},
 	}
 

--- a/src/repository/gorm2/game_creator_test.go
+++ b/src/repository/gorm2/game_creator_test.go
@@ -719,7 +719,7 @@ func TestGetGameCreatorsByUserIDs(t *testing.T) {
 			creators: []*schema.GameCreatorTable{creatorSchema1, creatorSchema2},
 			gameID:   values.NewGameIDFromUUID(creatorSchema1.Game.ID),
 			userIDs:  []values.TraPMemberID{creator1.GetUserID(), creator2.GetUserID()},
-			result:   []*domain.GameCreator{creator1, creator2},
+			result:   []*domain.GameCreator{creator2, creator1},
 		},
 		"該当するcreatorがいないので空配列": {
 			creators: []*schema.GameCreatorTable{creatorSchema1, creatorSchema2},

--- a/src/repository/gorm2/game_creator_test.go
+++ b/src/repository/gorm2/game_creator_test.go
@@ -664,3 +664,101 @@ func TestCreateGameCreators(t *testing.T) {
 		})
 	}
 }
+
+func TestGetGameCreatorsByUserIDs(t *testing.T) {
+	creatorSchema1 := &schema.GameCreatorTable{
+		ID:        uuid.New(),
+		UserID:    uuid.New(),
+		UserName:  "user",
+		CreatedAt: time.Now(),
+		Game: schema.GameTable2{
+			ID:               uuid.New(),
+			Name:             "game",
+			VisibilityTypeID: 1,
+		},
+	}
+	creator1 := domain.NewGameCreator(
+		values.GameCreatorID(creatorSchema1.ID),
+		values.NewTrapMemberID(creatorSchema1.UserID),
+		values.GameID(creatorSchema1.Game.ID),
+		values.NewTrapMemberName(creatorSchema1.UserName),
+		creatorSchema1.CreatedAt,
+	)
+	creatorSchema2 := &schema.GameCreatorTable{
+		ID:        uuid.New(),
+		UserID:    uuid.New(),
+		UserName:  "user",
+		CreatedAt: time.Now().Add(-time.Hour),
+		Game: schema.GameTable2{
+			ID:               creatorSchema1.Game.ID,
+			Name:             "game",
+			VisibilityTypeID: 1,
+		},
+	}
+	creator2 := domain.NewGameCreator(
+		values.GameCreatorID(creatorSchema2.ID),
+		values.NewTrapMemberID(creatorSchema2.UserID),
+		values.GameID(creatorSchema2.Game.ID),
+		values.NewTrapMemberName(creatorSchema2.UserName),
+		creatorSchema2.CreatedAt,
+	)
+
+	testCases := map[string]struct {
+		creators []*schema.GameCreatorTable
+		gameID   values.GameID
+		userIDs  []values.TraPMemberID
+		result   []*domain.GameCreator
+	}{
+		"ユーザー1人に対して1件のcreatorを取得できる": {
+			creators: []*schema.GameCreatorTable{creatorSchema1},
+			gameID:   values.NewGameIDFromUUID(creatorSchema1.Game.ID),
+			userIDs:  []values.TraPMemberID{creator1.GetUserID()},
+			result:   []*domain.GameCreator{creator1},
+		},
+		"複数ユーザーに対してcreatorを取得できる": {
+			creators: []*schema.GameCreatorTable{creatorSchema1, creatorSchema2},
+			gameID:   values.NewGameIDFromUUID(creatorSchema1.Game.ID),
+			userIDs:  []values.TraPMemberID{creator1.GetUserID(), creator2.GetUserID()},
+			result:   []*domain.GameCreator{creator1, creator2},
+		},
+		"該当するcreatorがいないので空配列": {
+			creators: []*schema.GameCreatorTable{creatorSchema1, creatorSchema2},
+			gameID:   values.NewGameID(),
+			userIDs:  []values.TraPMemberID{values.NewTrapMemberID(uuid.New())},
+			result:   []*domain.GameCreator{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			db, err := testDB.getDB(ctx)
+			require.NoError(t, err)
+
+			if len(testCase.creators) > 0 {
+				err = db.Create(testCase.creators).Error
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					db, err := testDB.getDB(context.Background())
+					require.NoError(t, err)
+					err = db.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(testCase.creators).Error
+					require.NoError(t, err)
+				})
+			}
+
+			repo := NewGameCreator(testDB)
+
+			result, err := repo.GetGameCreatorsByUserIDs(t.Context(), testCase.gameID, testCase.userIDs)
+
+			assert.NoError(t, err)
+			assert.Len(t, result, len(testCase.result))
+			for i, expected := range testCase.result {
+				assert.Equal(t, expected.GetID(), result[i].GetID())
+				assert.Equal(t, expected.GetGameID(), result[i].GetGameID())
+				assert.Equal(t, expected.GetUserID(), result[i].GetUserID())
+				assert.Equal(t, expected.GetUserName(), result[i].GetUserName())
+				assert.WithinDuration(t, expected.GetCreatedAt(), result[i].GetCreatedAt(), time.Second)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix #1528

- **:sparkles: repositoryのGetGameCreatorsByUserIDs実装**
- **:white_check_mark: GetGameCreatorsByUserIDsのテスト**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Game creators can now be efficiently retrieved and filtered by user IDs, enabling improved query performance.

* **Tests**
  * Added comprehensive test coverage for game creator retrieval, validating behavior across single users, multiple users, and cross-game scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->