### PR TITLE
:sparkles: GameCreatorsVisibilityAuth の checker 追加

### DIFF
--- a/src/handler/v2/checker.go
+++ b/src/handler/v2/checker.go
@@ -65,7 +65,7 @@ func (checker *Checker) check(ctx context.Context, input *openapi3filter.Authent
 		"EditionGameFeedbackAuth":    checker.EditionGameFeedbackAuthChecker,
 		"EditionIDAuth":              checker.EditionIDAuthChecker,
 		"GameInfoVisibilityAuth":     checker.GameInfoVisibilityChecker,
-		"GameFileVisibilityAuth":     checker.GameFileVisibilityChecker, // この3つは同じ条件のためえ、一つのチェッカーのみ実装している
+		"GameFileVisibilityAuth":     checker.GameFileVisibilityChecker, // この3つは同じ条件のため、一つのチェッカーのみ実装している
 		"GameImageVisibilityAuth":    checker.GameFileVisibilityChecker,
 		"GameVideoVisibilityAuth":    checker.GameFileVisibilityChecker,
 		"GameCreatorsVisibilityAuth": checker.GameInfoVisibilityChecker, // GameInfoVisibilityAuth と同じなため、そのまま持ってくる

--- a/src/handler/v2/checker.go
+++ b/src/handler/v2/checker.go
@@ -54,20 +54,21 @@ func NewChecker(
 func (checker *Checker) check(ctx context.Context, input *openapi3filter.AuthenticationInput) error {
 	// 一時的に未実装のものはチェックなしで通す
 	checkerMap := map[string]openapi3filter.AuthenticationFunc{
-		"TrapMemberAuth":          checker.TrapMemberAuthChecker,
-		"AdminAuth":               checker.AdminAuthChecker,
-		"GameOwnerAuth":           checker.GameOwnerAuthChecker,
-		"GameMaintainerAuth":      checker.GameMaintainerAuthChecker,
-		"EditionAuth":             checker.EditionAuthChecker,
-		"EditionGameFileAuth":     checker.EditionGameFileAuthChecker,
-		"EditionGameImageAuth":    checker.EditionGameImageAuthChecker,
-		"EditionGameVideoAuth":    checker.EditionGameVideoAuthChecker,
-		"EditionGameFeedbackAuth": checker.EditionGameFeedbackAuthChecker,
-		"EditionIDAuth":           checker.EditionIDAuthChecker,
-		"GameInfoVisibilityAuth":  checker.GameInfoVisibilityChecker,
-		"GameFileVisibilityAuth":  checker.GameFileVisibilityChecker, // この3つは同じ条件のためえ、一つのチェッカーのみ実装している
-		"GameImageVisibilityAuth": checker.GameFileVisibilityChecker,
-		"GameVideoVisibilityAuth": checker.GameFileVisibilityChecker,
+		"TrapMemberAuth":             checker.TrapMemberAuthChecker,
+		"AdminAuth":                  checker.AdminAuthChecker,
+		"GameOwnerAuth":              checker.GameOwnerAuthChecker,
+		"GameMaintainerAuth":         checker.GameMaintainerAuthChecker,
+		"EditionAuth":                checker.EditionAuthChecker,
+		"EditionGameFileAuth":        checker.EditionGameFileAuthChecker,
+		"EditionGameImageAuth":       checker.EditionGameImageAuthChecker,
+		"EditionGameVideoAuth":       checker.EditionGameVideoAuthChecker,
+		"EditionGameFeedbackAuth":    checker.EditionGameFeedbackAuthChecker,
+		"EditionIDAuth":              checker.EditionIDAuthChecker,
+		"GameInfoVisibilityAuth":     checker.GameInfoVisibilityChecker,
+		"GameFileVisibilityAuth":     checker.GameFileVisibilityChecker, // この3つは同じ条件のためえ、一つのチェッカーのみ実装している
+		"GameImageVisibilityAuth":    checker.GameFileVisibilityChecker,
+		"GameVideoVisibilityAuth":    checker.GameFileVisibilityChecker,
+		"GameCreatorsVisibilityAuth": checker.GameInfoVisibilityChecker, // GameInfoVisibilityAuth と同じなため、そのまま持ってくる
 	}
 
 	checkerFunc, ok := checkerMap[input.SecuritySchemeName]


### PR DESCRIPTION
fix #1589

`GameInfoVisibilityAuth` と同じなので、そのまま使う。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated code formatting and alignment for improved consistency in internal authentication configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/trap-collection-server/pull/1590)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->