### PR TITLE
repositoryのGetGameFeedback関連の実装

### DIFF
--- a/src/repository/game_feedback.go
+++ b/src/repository/game_feedback.go
@@ -1,0 +1,11 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+)
+
+type GameFeedback interface {
+	GetFeedbackConfig(ctx context.Context, gameID values.GameID, lockType LockType) (bool, error)
+}

--- a/src/repository/gorm2/game_feedback.go
+++ b/src/repository/gorm2/game_feedback.go
@@ -1,0 +1,48 @@
+package gorm2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/repository"
+	"github.com/traPtitech/trap-collection-server/src/repository/gorm2/schema"
+	"gorm.io/gorm"
+)
+
+type GameFeedback struct {
+	db *DB
+}
+
+var _ repository.GameFeedback = (*GameFeedback)(nil)
+
+func NewGameFeedback(db *DB) *GameFeedback {
+	return &GameFeedback{
+		db: db,
+	}
+}
+
+func (g *GameFeedback) GetFeedbackConfig(ctx context.Context, gameID values.GameID, lockType repository.LockType) (bool, error) {
+	db, err := g.db.getDB(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get db: %w", err)
+	}
+
+	db, err = g.db.setLock(db, lockType)
+	if err != nil {
+		return false, fmt.Errorf("failed to set lock: %w", err)
+	}
+
+	var config schema.GameFeedbackConfigTable
+	err = db.Where("game_id = ?", uuid.UUID(gameID)).Take(&config).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, repository.ErrRecordNotFound
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to get game feedback config: %w", err)
+	}
+
+	return config.Enabled, nil
+}

--- a/src/repository/gorm2/game_feedback_test.go
+++ b/src/repository/gorm2/game_feedback_test.go
@@ -1,0 +1,117 @@
+package gorm2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traPtitech/trap-collection-server/src/domain/values"
+	"github.com/traPtitech/trap-collection-server/src/repository"
+	"github.com/traPtitech/trap-collection-server/src/repository/gorm2/schema"
+)
+
+func TestGameFeedbackGetFeedbackConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, err := testDB.getDB(ctx)
+	require.NoError(t, err)
+
+	gameFeedbackRepository := NewGameFeedback(testDB)
+
+	var visibility schema.GameVisibilityTypeTable
+	err = db.
+		Where("name = ?", schema.GameVisibilityTypePublic).
+		Take(&visibility).Error
+	require.NoError(t, err)
+
+	gameIDEnabledTrue := values.NewGameID()
+	gameIDEnabledFalse := values.NewGameID()
+	gameIDNoConfig := values.NewGameID()
+
+	games := []schema.GameTable2{
+		{
+			ID:               uuid.UUID(gameIDEnabledTrue),
+			Name:             "feedback config enabled true",
+			Description:      "description",
+			VisibilityTypeID: visibility.ID,
+			CreatedAt:        time.Now(),
+		},
+		{
+			ID:               uuid.UUID(gameIDEnabledFalse),
+			Name:             "feedback config enabled false",
+			Description:      "description",
+			VisibilityTypeID: visibility.ID,
+			CreatedAt:        time.Now(),
+		},
+		{
+			ID:               uuid.UUID(gameIDNoConfig),
+			Name:             "feedback config no config",
+			Description:      "description",
+			VisibilityTypeID: visibility.ID,
+			CreatedAt:        time.Now(),
+		},
+	}
+	require.NoError(t, db.Create(&games).Error)
+
+	configs := []schema.GameFeedbackConfigTable{
+		{
+			GameID:  uuid.UUID(gameIDEnabledTrue),
+			Enabled: true,
+		},
+		{
+			GameID:  uuid.UUID(gameIDEnabledFalse),
+			Enabled: false,
+		},
+	}
+	require.NoError(t, db.Create(&configs).Error)
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		cleanupDB, err := testDB.getDB(cleanupCtx)
+		require.NoError(t, err)
+
+		require.NoError(t, cleanupDB.Unscoped().Delete(&configs).Error)
+		require.NoError(t, cleanupDB.Unscoped().Delete(&games).Error)
+	})
+
+	testCases := map[string]struct {
+		gameID        values.GameID
+		expectedValue bool
+		expectedErr   error
+	}{
+		"enabledがtrueの設定を取得できる": {
+			gameID:        gameIDEnabledTrue,
+			expectedValue: true,
+		},
+		"enabledがfalseの設定を取得できる": {
+			gameID:        gameIDEnabledFalse,
+			expectedValue: false,
+		},
+		"設定レコードが存在しない場合ErrRecordNotFound": {
+			gameID:      gameIDNoConfig,
+			expectedErr: repository.ErrRecordNotFound,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			enabled, err := gameFeedbackRepository.GetFeedbackConfig(
+				ctx,
+				testCase.gameID,
+				repository.LockTypeNone,
+			)
+
+			if testCase.expectedErr != nil {
+				assert.ErrorIs(t, err, testCase.expectedErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedValue, enabled)
+		})
+	}
+}


### PR DESCRIPTION
close #1548
src/repository/game_feedback.go
src/repository/gorm2/game_feedback.go
src/repository/gorm2/game_feedback_test.go
を新規作成して実装しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database persistence layer for managing game feedback configurations, with support for transactional locking mechanisms and comprehensive error handling to ensure data integrity.
  * Implemented extensive test coverage for feedback configuration retrieval operations, thoroughly validating behavior across various game states and edge cases, including missing configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/trap-collection-server/pull/1591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->