### PR TITLE
fix: deprecatedなGetSwaggerをGetSpecに置き換え

### DIFF
--- a/src/handler/v2/api.go
+++ b/src/handler/v2/api.go
@@ -98,7 +98,7 @@ func (api *API) Start(addr string) error {
 }
 
 func (api *API) setRoutes(e *echo.Echo) error {
-	swagger, err := openapi.GetSwagger()
+	spec, err := openapi.GetSpec()
 	if err != nil {
 		return fmt.Errorf("failed to get openapi: %w", err)
 	}
@@ -107,7 +107,7 @@ func (api *API) setRoutes(e *echo.Echo) error {
 	// 他のrouteにはoapiMiddleware.OapiRequestValidatorを設定したくないため、
 	// 空のpathのgroupを作成し、oapiMiddleware.OapiRequestValidatorを設定する
 	apiGroup := e.Group("")
-	apiGroup.Use(echomiddleware.OapiRequestValidatorWithOptions(swagger, &echomiddleware.Options{
+	apiGroup.Use(echomiddleware.OapiRequestValidatorWithOptions(spec, &echomiddleware.Options{
 		Skipper: fileUploadSkipper,
 		Options: openapi3filter.Options{
 			AuthenticationFunc: api.check,


### PR DESCRIPTION
## Summary
- `openapi.GetSwagger()` (deprecated) を `openapi.GetSpec()` に変更
- staticcheck SA1019 警告を解消し、mainのCIのLintジョブを修正

## Test plan
- [ ] CIのLintジョブがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal API specification handling to use an improved loading mechanism while maintaining all existing validation and authentication functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->